### PR TITLE
Enable ranking within the aggregate service

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The following environment variables can be used to configure the server:
 
 - `NODE_ENV` : the environment mode, either `production` or `development` (default)
 - `PORT` : the port on which the server runs (default 3000)
+- `MAX_SEARCH_ES` : the maximum number of results to return from elasticsearch
+- `MAX_SEARCH_WS` : the maximum number of results to return in json from the webservice
 - `INPUT_PATH` : the path to the input folder where data files are located
 - `INDEX` : the elasticsearch index name to store data from all data sources
 - `UNIPROT_FILE_NAME` : name of the file where uniprot data will be read from

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 
 let defaults = {
   PORT: 3000,
-  MAX_SEARCH_ES: 100,
+  MAX_SEARCH_ES: 1000,
   MAX_SEARCH_WS: 100, // reduce this number later (probably 10 is ok)
   INDEX: 'groundingsearch',
   INPUT_PATH: 'input',

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -3,6 +3,8 @@ const _ = require('lodash');
 
 let defaults = {
   PORT: 3000,
+  MAX_SEARCH_ES: 100,
+  MAX_SEARCH_WS: 100, // reduce this number later (probably 10 is ok)
   INDEX: 'groundingsearch',
   INPUT_PATH: 'input',
   UNIPROT_FILE_NAME: 'uniprot.xml',

--- a/src/server/datasource/aggregate.js
+++ b/src/server/datasource/aggregate.js
@@ -1,15 +1,33 @@
 const db = require('../db');
+const { rankInThread } = require('./rank');
+const { MAX_SEARCH_WS } = require('../config');
 
 /**
  * Retrieve the entities matching best with the search string.
  * @param {string} searchString Key string for searching the best matching entities.
+ * @param {object} [organismCounts] An object map of organism taxon IDs to the
+ * relative weight of the organisms.  Example: `{ '9606': 3, '10090': 1 }`
+ * This sets a preference of organism ordering when there is a distance tie (e.g.
+ * P53 for human or P53 for mouse).  The counts ould be, for example, the number
+ * of times an organism is mentioned in a document or the number of prior groundings
+ * associated with that organism in a document.  If not specified, a default ordering
+ * is used based on the popularity of common model organisms.
  * @returns {Promise} Promise object represents the array of best matching entries.
  */
-const search = function(searchString){
-  // for now no sorting...
+const search = function(searchString, organismCounts){
+  const doSearch = () => db.search(searchString);
+  const doRank = ents => rankInThread(ents, searchString, organismCounts);
+  const shortenList = ents => ents.slice(0, MAX_SEARCH_WS);
 
-  // something more sophisticated could be done later
-  return db.search(searchString);
+  // TODO other specific datasources should also rank or maybe move this function
+  // logic to db.js
+
+  return (
+    Promise.resolve()
+      .then(doSearch)
+      .then(doRank)
+      .then(shortenList)
+  );
 };
 
 /**

--- a/src/server/datasource/organisms.js
+++ b/src/server/datasource/organisms.js
@@ -13,15 +13,13 @@ const SORTED_MAIN_ORGANISMS = [
   '7955' // d. rerio
 ];
 
-const SUPPORTED_ORGANISMS = new Set(SORTED_MAIN_ORGANISMS);
-
 /**
  * Get whether an organism is supported by the system and should be shown in search
  * results.
  * @param {string} id The organism taxon ID
  */
-const isSupportedOrganism = id => {
-  return SUPPORTED_ORGANISMS.has( id ); // TODO should eventually just allow all
+const isSupportedOrganism = id => { // eslint-disable-line no-unused-vars
+  return true; // all organisms are supported
 };
 
 /**

--- a/src/server/datasource/rank.js
+++ b/src/server/datasource/rank.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
-const { getDefaultOrganismIndex } = require('./datasource/organisms');
+const { getDefaultOrganismIndex } = require('./organisms');
 const dice = require('dice-coefficient'); // sorensen dice coeff
+const Future = require('fibers/future');
 
 const DISTANCE_FIELDS = ['name', 'synonyms']; // TODO should share list with db.js
 
@@ -12,7 +13,7 @@ const DISTANCE_FIELDS = ['name', 'synonyms']; // TODO should share list with db.
  * lower values indicating a smaller distance between the strings.
  */
 const stringDistanceMetric = (a, b) => {
-  return 1 - dice(a, b);
+  return 1 - dice(a.toLowerCase(), b.toLowerCase());
 };
 
 /**
@@ -56,18 +57,19 @@ const getDistance = (ent, searchTerm) => {
  * @param {EntityJSON} ents An array of entities to sort.
  * @param {string} searchTerm The search term used for sorting the entities.
  * @param {object} [organismCounts] An object map of organism taxon IDs to the
- * relative weight of the organisms.  This sets a preference of organism ordering
- * when there is a distance tie (e.g. P53 for human or P53 for mouse).  The counts
- * could be, for example, the number of times an organism is mentioned in a document
- * or the number of prior groundings associated with that organism in a document.
- * If not specified, a default ordering is used based on the popularity of common
- * model organisms.
+ * relative weight of the organisms.  Example: `{ '9606': 3, '10090': 1 }`
+ * This sets a preference of organism ordering when there is a distance tie (e.g.
+ * P53 for human or P53 for mouse).  The counts ould be, for example, the number
+ * of times an organism is mentioned in a document or the number of prior groundings
+ * associated with that organism in a document.  If not specified, a default ordering
+ * is used based on the popularity of common model organisms.
  * @returns The sorted, ranked array of entities.  The best matches come first.
  */
 const rank = (ents, searchTerm, organismCounts = {}) => {
   let dist = ent => getDistance(ent, searchTerm);
 
   let orgCount = ent => ent.organism == null ? 0 : (organismCounts[ent.organism] || 0);
+  let defOrgCount = ent => ent.organism == null ? 0 : getDefaultOrganismIndex(ent.organism);
 
   let sortByDistThenOrgs = (a, b) => {
     let distDiff = dist(a) - dist(b);
@@ -76,7 +78,7 @@ const rank = (ents, searchTerm, organismCounts = {}) => {
       let orgDiff = orgCount(b) - orgCount(a);
 
       if( orgDiff === 0 ){
-        let defaultOrgDiff = getDefaultOrganismIndex(a) - getDefaultOrganismIndex(b);
+        let defaultOrgDiff = defOrgCount(a) - defOrgCount(b);
 
         return defaultOrgDiff;
       } else {
@@ -90,5 +92,15 @@ const rank = (ents, searchTerm, organismCounts = {}) => {
   return ents.sort(sortByDistThenOrgs);
 };
 
+const rankInThread = (ents, searchTerm, organismCounts) => {
+  let task = Future.wrap(function(args, next){ // code in this block runs in its own thread
+    let res = rank(args.ents, args.searchTerm, args.organismCounts);
+    let err = null;
 
-module.exports = { rank };
+    next( err, res );
+  });
+
+  return task({ ents, searchTerm, organismCounts }).promise();
+};
+
+module.exports = { rank, rankInThread };

--- a/src/server/db/db.js
+++ b/src/server/db/db.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const elasticsearch = require('elasticsearch');
-const { INDEX } = require('../config');
+const { INDEX, MAX_SEARCH_ES } = require('../config');
 
 const TYPE = 'entry';
 const META_SEARCH_FIELD = 'meta_search';
@@ -161,7 +161,7 @@ let db = {
   },
   /**
    * Create elasticsearch index for the app if it is not already existing.
-   * @returns {Promise} 
+   * @returns {Promise}
    */
   guaranteeIndex: function(){
     let indexExists = () => this.exists();
@@ -180,7 +180,7 @@ let db = {
   /**
    * Delete the entries of given namespace.
    * @param {string} namespace The namespace to clear
-   * @returns {Promise} 
+   * @returns {Promise}
    */
   clearNamespace: function( namespace ){
     let client = this.connect();
@@ -209,8 +209,8 @@ let db = {
    * Insert the given entries to elasticsearch index dedicated for the app as a chunk.
    * @param {array} entries Entries to be inserted.
    * @param {boolean} [refresh=false] Whether to refresh the index after the operation is completed.
-   * This parameter should be used carefully because refreshing after every insert would decrease 
-   * the performance. 
+   * This parameter should be used carefully because refreshing after every insert would decrease
+   * the performance.
    * See: https://www.elastic.co/guide/en/elasticsearch/guide/current/near-real-time.html#refresh-api
    * @returns {Promise}
    */
@@ -237,14 +237,14 @@ let db = {
    * @param {string} [size=50] Maximum amount of hits to be returned.
    * @returns {Promise} Promise object represents the array of best matching entities.
    */
-  search: function( searchkey, namespace, from = 0, size = 50 ){
+  search: function( searchkey, namespace, from = 0, size = MAX_SEARCH_ES ){
     return search( searchkey, META_SEARCH_FIELD, namespace, from, size );
   },
   /**
    * Retrieve the entity that has the given id.
    * @param {string} id The id of entity to search
    * @param {string} [namespace=undefined] Namespace to seek the entity e.g. 'uniprot', 'chebi', ...
-   * @returns {Promise} Promise objects represents the entity with the given id from the given namespace, 
+   * @returns {Promise} Promise objects represents the entity with the given id from the given namespace,
    * if there is no such entity it represents null.
    */
   get: function( id, namespace ){

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -5,8 +5,20 @@ const chebi = require('../datasource/chebi');
 const ncbi = require('../datasource/ncbi');
 const aggregate = require('../datasource/aggregate');
 
+const dsNsMap = new Map([
+  ['ncbi', ncbi],
+  ['chebi', chebi],
+  ['uniprot', uniprot],
+  ['aggregate', aggregate]
+]);
+
+const getDataSource = ns => dsNsMap.get(ns);
+
 const handleReq = (source, req, res) => {
-  source.search(req.body.q).then(searchRes => res.json(searchRes));
+  const q = req.body.q;
+  const orgCounts = req.body.organismCounts;
+
+  source.search(q, orgCounts).then(searchRes => res.json(searchRes));
 };
 
 /* GET home page. */
@@ -107,7 +119,23 @@ router.post('/ncbi', function(req, res){
  */
 // e.g. POST /search { q: 'p53' }
 router.post('/search', function(req, res){
-  handleReq(aggregate, req, res);
+  const { namespace } = req.body; // allow specifying namespace filter
+  let datasource;
+
+  if( namespace != null ){
+    datasource = getDataSource(namespace);
+  } else {
+    datasource = aggregate;
+  }
+
+  handleReq(datasource, req, res);
+});
+
+// TODO swagger docs
+router.post('/get', function(req, res){
+  const { namespace, id } = req.body;
+
+  aggregate.get(namespace, id).then(searchRes => res.json(searchRes));
 });
 
 module.exports = router;

--- a/test/aggregate-quality.js
+++ b/test/aggregate-quality.js
@@ -1,8 +1,8 @@
-const { expect, should } = require('../util/chai');
-const { aggregate, applyToEachDS , datasources, uniprot, chebi} = require('../util/datasource');
-const { forceDownload, maxSearchSize, buildIndex } = require('../util/param');
-const { SEARCH_OBJECT } = require('../util/search');
-const db = require('../../src/server/db');
+const { expect, should } = require('./util/chai');
+const { aggregate, applyToEachDS , datasources, uniprot, chebi} = require('./util/datasource');
+const { forceDownload, maxSearchSize, buildIndex } = require('./util/param');
+const { SEARCH_OBJECT } = require('./util/search');
+const db = require('../src/server/db');
 const _ = require('lodash');
 
 const updateTestData = () => {

--- a/test/aggregate-quality.js
+++ b/test/aggregate-quality.js
@@ -1,9 +1,8 @@
-const { expect, should } = require('./util/chai');
-const { aggregate, applyToEachDS , datasources, uniprot, chebi} = require('./util/datasource');
-const { forceDownload, maxSearchSize, buildIndex } = require('./util/param');
+const { expect } = require('./util/chai');
+const { aggregate, applyToEachDS } = require('./util/datasource');
+const { forceDownload, buildIndex } = require('./util/param');
 const { SEARCH_OBJECT } = require('./util/search');
 const db = require('../src/server/db');
-const _ = require('lodash');
 
 const updateTestData = () => {
   let guaranteeIndex = () => db.guaranteeIndex();
@@ -14,12 +13,8 @@ const updateTestData = () => {
 const searchEnt = name => aggregate.search( name );
 const getEnt = (ns, id) => aggregate.get( ns, id );
 const removeTestIndex = () => db.deleteIndex();
-const getFirstId = e => _.get( e, [ 0, 'id' ] );
 
-const GROUNDING_LIST = Object.values( SEARCH_OBJECT );
 const GENE_LIST = Object.keys( SEARCH_OBJECT );
-
-const groundingSpecified = name => SEARCH_OBJECT[name] != null;
 
 describe('Search and Get Aggregate', function(){
   if ( buildIndex ) {

--- a/test/aggregate-verification.js
+++ b/test/aggregate-verification.js
@@ -1,4 +1,4 @@
-const { expect, should } = require('./util/chai');
+const { expect } = require('./util/chai');
 const { aggregate, applyToEachDS } = require('./util/datasource');
 const { forceDownload, buildIndex } = require('./util/param');
 const db = require('../src/server/db');

--- a/test/datasource.js
+++ b/test/datasource.js
@@ -1,6 +1,4 @@
-const { expect, should } = require('./util/chai');
-const xmljs = require('xml-js');
-const fs = require('fs');
+const { expect } = require('./util/chai');
 const _ = require('lodash');
 const db = require('../src/server/db');
 const { forceDownload, maxSearchSize } = require('./util/param');

--- a/test/ncbi.js
+++ b/test/ncbi.js
@@ -1,7 +1,5 @@
-const xmljs = require('xml-js');
 const path = require('path');
 const fs = require('fs');
-const _ = require('lodash');
 const StringDecoder = require('string_decoder').StringDecoder;
 
 const DatasourceTest = require('./datasource');

--- a/test/temp/aggregate.js
+++ b/test/temp/aggregate.js
@@ -37,8 +37,11 @@ describe('Search and Get Aggregate', function(){
     it(`search ${name}`, function(){
       return ( searchEnt(name)
         .then( results => {
+          expect(results).to.exist;
+
           let firstResult = results[0];
 
+          expect(firstResult).to.exist;
           expect(firstResult.namespace, 'namespace').to.equal(namespace);
           expect(firstResult.id, 'id').to.equal(id);
         } )
@@ -48,6 +51,7 @@ describe('Search and Get Aggregate', function(){
     it(`get ${name}`, function(){
       return ( getEnt(namespace, id)
         .then( result => {
+          expect(result, 'result').to.exist;
           expect(result.namespace, 'namespace').to.equal(namespace);
           expect(result.id, 'id').to.equal(id);
         } )

--- a/test/temp/aggregate.js
+++ b/test/temp/aggregate.js
@@ -19,14 +19,19 @@ const getFirstId = e => _.get( e, [ 0, 'id' ] );
 const GROUNDING_LIST = Object.values( SEARCH_OBJECT );
 const GENE_LIST = Object.keys( SEARCH_OBJECT );
 
+const groundingSpecified = name => SEARCH_OBJECT[name] != null;
+
 describe('Search and Get Aggregate', function(){
   if ( buildIndex ) {
     before(updateTestData);
     after(removeTestIndex);
   }
 
-  GENE_LIST.forEach( (name, i) => {
-    const expectedGrounding = GROUNDING_LIST[i] || {}; // could be null b/c we haven't specified groundings yet...
+  GENE_LIST.forEach( name => {
+    const expectedGrounding = SEARCH_OBJECT[name]; // could be null b/c we haven't specified groundings yet...
+
+    if( !expectedGrounding ){ return; } // skip if no grounding specified
+
     const { id, namespace } = expectedGrounding;
 
     it(`search ${name}`, function(){

--- a/test/temp/aggregate.js
+++ b/test/temp/aggregate.js
@@ -46,7 +46,7 @@ describe('Search and Get Aggregate', function(){
     });
 
     it(`get ${name}`, function(){
-      return ( getEnt(id, namespace)
+      return ( getEnt(namespace, id)
         .then( result => {
           expect(result.namespace, 'namespace').to.equal(namespace);
           expect(result.id, 'id').to.equal(id);


### PR DESCRIPTION
- Ranking now happens in a separate thread for performance.
- The default result size is now 100 to make up for current so-so elasticsearch sorting.
- Add `MAX_SEARCH_ES` and `MAX_SEARCH_WS` to control the max return size for elasticsearch and for the webservice.  We need a higher return size for elasticsearch to do our own sorting.  The webservice only needs to return a small size (e.g. 10) because a user isn't going to look farther than that anyway.  And we need to make sure, realistically, that the expected result is at least in the top 3.
- Add support in the `/search` webservice to filter by a datasource `namespace`.  This could remove the need for separate endpoints like `/uniprot`.  Removing those endpoints and updating the swagger docs is still TODO.
- Updating the other individual datasources to use the ranking is still TODO.  The function should probably be pulled out of `aggregate` and made re-usable.
- Improving the default results of elasticsearch is also TODO.  The effectiveness of elasticsearch should also be maximised to avoid edgecases where `MAX_SEARCH_ES` is not large enough.