### PR TITLE
Check groundings

### DIFF
--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1527,6 +1527,7 @@
   },
   {
    "id": "http://dx.doi.org/10.1016/j.molcel.2017.01.027",
+   "organismOrdering": [9606],
    "entities": [
     {
       "text": "Beclin1",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1683,6 +1683,7 @@
   },
   {
    "id": "https://doi.org/10.1016/j.molcel.2018.08.014",
+   "organismOrdering": [9606],
    "entities": [
       {
         "text": "myc",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1395,6 +1395,7 @@
   },
   {
    "id": "http://dx.doi.org/10.1016/j.molcel.2017.02.016",
+   "organismOrdering": [3702],
    "entities": [
     {
       "text": "CBF",


### PR DESCRIPTION
RE #18 

The groundings that were extracted are all correct -- relevant entities, right organism, tumor proteins if the paper speaks about tumor... What is obvious to me though, is that a lot is not picked up. It's very correct, but very conservative (which is not bad, per-se).

Another point is that it picks up families but it doesn't ground them to anything. This is known, I suppose. I also wonder what would be a good database for these (I was just looking around myself for this but apart from sparse wikipedia pages, I couldn't find a reliable resource).