### PR TITLE
Partial test json review

### DIFF
--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1465,6 +1465,7 @@
      {
       "text": "AtCIPK3",
       "xref_id": "817240",
+      "loose": true,
       "namespace": "ncbi",
       "sentence": "Other protein kinases , including the mitogen activated protein kinase kinase 2 ( MKK2 ) and CBL interacting protein kinase 3 ( AtCIPK3 ) , have been implicated in plant cold responses ( Kim et al. , 2003 , Teige et al. , 2004 ) ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -205,7 +205,7 @@
     },
     {
      "text": "4-OHT",
-     "xref_id": "41774",
+     "xref_id": "44616",
      "namespace": "chebi",
      "sentence": "In this system , treatment of control cells with 4-hydroxy-tamoxifen ( 4-OHT ) and the Shield-1 ligand induces DNA damage , as evident by a single 53BP1 focus , and an enrichment of H4K16 acetylation at break ends                       ( Shanbhag et al. , 2010 , Tang et al. , 2013 ) ."
     },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1899,6 +1899,7 @@
      {
       "text": "IFNlambda",
       "xref_id": "282618",
+      "loose": true,
       "namespace": "ncbi",
       "sentence": "For WT and S8E , we observed robust induction of IFIT1 protein and secretion of IFNlambda upon FLUAV infection , whereas phosphomimetics of the cluster I residues , including the individual T667E mutation , almost completely abrogated IFIT1 and IFNlambda induction                    ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -2182,6 +2182,7 @@
      {
       "text": "JUNB",
       "xref_id": "3726",
+      "loose": true,
       "namespace": "ncbi",
       "sentence": "A recent report has shown that lincRNA-p21 can bind JUNB and CTNNB1 mRNAs and suppress their translation ( Yoon et al. , 2012 ) ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1636,8 +1636,9 @@
       "text": "phosphate",
       "xref_id": "18367",
       "namespace": "chebi",
-      "sentence": "DAPK1 kinase activity has been described to be strictly inhibited by autophosphorylation at serine 308 ( S308 ) ; only upon removal of this phosphate DAPK1 kinase becomes active again ( Shohat et al. , 2002 ) ."
-     },
+      "sentence": "DAPK1 kinase activity has been described to be strictly inhibited by autophosphorylation at serine 308 ( S308 ) ; only upon removal of this phosphate DAPK1 kinase becomes active again ( Shohat et al. , 2002 ) .",
+      "loose": true
+    },
      {
       "text": "3-phosphoglycerate",
       "xref_id": "17794",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -816,7 +816,8 @@
       "text": "hydrogen",
       "xref_id": "49637",
       "namespace": "chebi",
-      "sentence": "Indeed , while methylation does not change the overall charge of the residue , it does alter the availability of hydrogen donors and increases van der Waals interactive forces ( Liu et al. , 2010 , Yang et al. , 2010 ) ."
+      "sentence": "Indeed , while methylation does not change the overall charge of the residue , it does alter the availability of hydrogen donors and increases van der Waals interactive forces ( Liu et al. , 2010 , Yang et al. , 2010 ) .",
+      "loose": true
      },
      {
       "text": "TRRAP",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1556,6 +1556,7 @@
      {
       "text": "ARD1",
       "xref_id": "8260",
+      "loose": true,
       "namespace": "ncbi",
       "sentence": "Here , we demonstrate that glutamine deprivation and hypoxia result in inhibition of mTOR mediated acetyl-transferase ARD1 S228 phosphorylation , leading to ARD1 dependent phosphoglycerate kinase 1 ( PGK1 ) K388 acetylation and subsequent PGK1 mediated Beclin1 S30 phosphorylation ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -108,6 +108,7 @@
     {
      "text": "nitrogen",
      "xref_id": "25555",
+     "loose": true,
      "namespace": "chebi",
      "sentence": "Dimethylation can occur asymmetrically ( ADMA ) , with two methyl groups placed onto one of the terminal nitrogen atoms of the guanidino group , or symmetrically ( SDMA ) , where one methyl group is placed onto each of the terminal nitrogen atoms ."
     },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -603,7 +603,8 @@
       "text": "Rif1",
       "xref_id": "55183",
       "namespace": "ncbi",
-      "sentence": "The main determinant for HR mediated repair is resection of the DNA DSB end , which is controlled by a 53BP1 containing protein complex containing Rif1 , PTIP , and Rev7 ( Panier and Boulton , 2014 ) ."
+      "sentence": "The main determinant for HR mediated repair is resection of the DNA DSB end , which is controlled by a 53BP1 containing protein complex containing Rif1 , PTIP , and Rev7 ( Panier and Boulton , 2014 ) .",
+      "loose": true
      },
      {
       "text": "PTIP",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1187,7 +1187,7 @@
      },
      {
       "text": "Snail3",
-      "xref_id": " 333929",
+      "xref_id": "333929",
       "namespace": "ncbi",
       "sentence": "Five among the 96 TFs were activated more than 1.8-fold when cells were cultured under detached conditions , including PLAG1 , SATB1 , and Snail3            ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1737,6 +1737,7 @@
       {
         "text": "p130",
         "xref_id": "5934",
+        "loose": true,
         "namespace": "ncbi",
         "sentence": "In quiescent cells , genes required for DNA synthesis are silenced by the Retinoblastoma ( RB ) family of pocket proteins ( RB , p107 , and p130 ) tethered to DNA via repressive E2F family members ( E2F4/5 ) ( Rayman et al. , 2002 ; Takahashi et al. , 2000 ) ."
       },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1261,8 +1261,9 @@
       "text": "ARD1",
       "xref_id": "8260",
       "namespace": "ncbi",
-      "sentence": "Here , we demonstrate that glutamine deprivation and hypoxia result in inhibition of mTOR mediated acetyl-transferase ARD1 S228 phosphorylation , leading to ARD1 dependent phosphoglycerate kinase 1 ( PGK1 ) K388 acetylation and subsequent PGK1 mediated Beclin1 S30 phosphorylation ."
-     },
+      "sentence": "Here , we demonstrate that glutamine deprivation and hypoxia result in inhibition of mTOR mediated acetyl-transferase ARD1 S228 phosphorylation , leading to ARD1 dependent phosphoglycerate kinase 1 ( PGK1 ) K388 acetylation and subsequent PGK1 mediated Beclin1 S30 phosphorylation .",
+      "loose": true
+    },
      {
       "text": "VPS34",
       "xref_id": "5289",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -163,6 +163,7 @@
     {
      "text": "KAP1",
      "xref_id": "10155",
+     "loose": true,
      "namespace": "ncbi",
      "sentence": "In contrast , activation of the ATM signaling cascade , determined by the phosphorylation of ATM and its downstream substrates CHK2 and KAP1 , was unaffected by PRMT5 depletion                     ."
     },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -694,6 +694,7 @@
      {
       "text": "nitrogen",
       "xref_id": "25555",
+      "loose": true,
       "namespace": "chebi",
       "sentence": "Dimethylation can occur asymmetrically ( ADMA ) , with two methyl groups placed onto one of the terminal nitrogen atoms of the guanidino group , or symmetrically ( SDMA ) , where one methyl group is placed onto each of the terminal nitrogen atoms ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1713,7 +1713,7 @@
       {
         "text": "p19Arf",
         "xref_id": "1029",
-        "namespace": "uniprot",
+        "namespace": "ncbi",
         "sentence": "This biphasic pattern was also reflected in other nodes in immediate network including the miR-17-92 micro RNA cluster and p19Arf ."
       },
       {

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1641,6 +1641,7 @@
      {
       "text": "3-phosphoglycerate",
       "xref_id": "17794",
+      "loose": true,
       "namespace": "chebi",
       "sentence": "This conclusion was further strengthened by glucose flux analysis , using 13C labeled glucose , where a similar decrease in labeled glucose-6-phosphate , 3-phosphoglycerate , and lactate was observed with the knockdown of Foxk1 or Hif-1alpha                ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -225,7 +225,8 @@
      "text": "hydrogen",
      "xref_id": "49637",
      "namespace": "chebi",
-     "sentence": "Indeed , while methylation does not change the overall charge of the residue , it does alter the availability of hydrogen donors and increases van der Waals interactive forces ( Liu et al. , 2010 , Yang et al. , 2010 ) ."
+     "sentence": "Indeed , while methylation does not change the overall charge of the residue , it does alter the availability of hydrogen donors and increases van der Waals interactive forces ( Liu et al. , 2010 , Yang et al. , 2010 ) .",
+     "loose": true
     },
     {
      "text": "TRRAP",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -2188,6 +2188,7 @@
      {
       "text": "miR-130",
       "xref_id": "406919",
+      "loose": true,
       "namespace": "ncbi",
       "sentence": "In addition to lncRNAs , several hypoxia and HIF-1alpha-induced miRNAs , such as miR-130 and miR-155 , have recently been shown to inhibit HIF-1alpha expression by targeting its 3 ' UTR or hampering its translation , thereby forming a negative feedback loop to control hypoxia response ( Bruning et al. , 2011 , Saito et al. , 2011 ) ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1996,7 +1996,7 @@
      {
       "text": "p19Arf",
       "xref_id": "1029",
-      "namespace": "uniprot",
+      "namespace": "ncbi",
       "sentence": "This biphasic pattern was also reflected in other nodes in immediate network including the miR-17-92 micro RNA cluster and p19Arf ."
      },
      {

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1345,6 +1345,7 @@
      {
       "text": "3-phosphoglycerate",
       "xref_id": "17794",
+      "loose": true,
       "namespace": "chebi",
       "sentence": "This conclusion was further strengthened by glucose flux analysis , using 13C labeled glucose , where a similar decrease in labeled glucose-6-phosphate , 3-phosphoglycerate , and lactate was observed with the knockdown of Foxk1 or Hif-1alpha                ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -2020,6 +2020,7 @@
      {
       "text": "p130",
       "xref_id": "5934",
+      "loose": true,
       "namespace": "ncbi",
       "sentence": "In quiescent cells , genes required for DNA synthesis are silenced by the Retinoblastoma ( RB ) family of pocket proteins ( RB , p107 , and p130 ) tethered to DNA via repressive E2F family members ( E2F4/5 ) ( Rayman et al. , 2002 ; Takahashi et al. , 2000 ) ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -48,7 +48,8 @@
      "text": "Rif1",
      "xref_id": "55183",
      "namespace": "ncbi",
-     "sentence": "The main determinant for HR mediated repair is resection of the DNA DSB end , which is controlled by a 53BP1 containing protein complex containing Rif1 , PTIP , and Rev7 ( Panier and Boulton , 2014 ) ."
+     "sentence": "The main determinant for HR mediated repair is resection of the DNA DSB end , which is controlled by a 53BP1 containing protein complex containing Rif1 , PTIP , and Rev7 ( Panier and Boulton , 2014 ) .",
+     "loose": true
     },
     {
      "text": "BRCA1",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1163,6 +1163,7 @@
      {
       "text": "CaM",
       "xref_id": "801",
+      "loose": true,
       "namespace": "ncbi",
       "sentence": "DAPK1 is a 160-kDa Ca2 +-/calmodulin ( CaM )-dependent serine/threonine kinase , comprised of an N-terminal kinase domain followed by a regulatory CaM binding domain , eight Ankyrin repeats , a cytoskeleton associating ROC-COR domain and a C-terminal death domain ( schematic in Figure 4A , interaction network in Figure S1B ) ( Carlessi et al. , 2011 ) ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -360,8 +360,9 @@
       "sentence": "The broad control that mTORC1 exerts over metabolism has been largely attributed to the regulation of a small number of transcription factors , including c-Myc , Srebp1/2 , Hif-1alpha , Atf4 , and Tfeb , although in most cases the molecular mechanisms remain unclear ( Laplante and Sabatini , 2013 , Ben-Sahra and Manning , 2017 ) ."
      },
      {
-      "text": "sugar",
+      "text": "glucose",
       "xref_id": "4167",
+      "loose": true,
       "namespace": "chebi",
       "sentence": "Consistent with the results attained with this platform , we also observed that Foxk1 knockdown significantly and specifically reduced glucose uptake in these cells            , which resides at the apex of sugar metabolism , thus supporting a significant role of Foxk1 as a critical regulator of glucose metabolism ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1965,7 +1965,8 @@
       "sentence": "One such functional module is glucose metabolism ( Data S2 , cluster 17 ) : out of four kinase activities required for core glycolysis , isoforms of three were identified as hit candidates in our screen ( HK2 , PKLR , and PFKL ) ."
      },
      {
-      "text": "DAKP1",
+      "text": "DAPK1",
+      "note": "typo in paper text",
       "xref_id": "1612",
       "namespace": "ncbi",
       "sentence": "Activation of DAKP1 with the protonophore CCCP served as a positive control ( bottom panel ) ."

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1874,7 +1874,7 @@
      },
      {
       "text": "AAK1",
-      "xref_id": "Q2M2I8",
+      "xref_id": "22848",
       "namespace": "ncbi",
       "sentence": "Twenty-one identified hits ( AAK1 was excluded for technical reasons ) were further characterized with respect to their effect on RIG-I-mediated IRF3 activation upon knockdown or overexpression in 293TRIG-I cells ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1742,7 +1742,7 @@
       },
       {
         "text": "RB",
-        "xref_id": " 5925",
+        "xref_id": "5925",
         "namespace": "ncbi",
         "sentence": "In quiescent cells , genes required for DNA synthesis are silenced by the Retinoblastoma ( RB ) family of pocket proteins ( RB , p107 , and p130 ) tethered to DNA via repressive E2F family members ( E2F4/5 ) ( Rayman et al. , 2002 ; Takahashi et al. , 2000 ) ."
       },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1906,6 +1906,7 @@
      {
       "text": "inositol",
       "xref_id": "17268",
+      "loose": true,
       "namespace": "chebi",
       "sentence": "The Krishnan screen revealed a functionally important role of inositol pyrophosphates in the induction of type I IFN ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -2025,7 +2025,7 @@
      },
      {
       "text": "RB",
-      "xref_id": " 5925",
+      "xref_id": "5925",
       "namespace": "ncbi",
       "sentence": "In quiescent cells , genes required for DNA synthesis are silenced by the Retinoblastoma ( RB ) family of pocket proteins ( RB , p107 , and p130 ) tethered to DNA via repressive E2F family members ( E2F4/5 ) ( Rayman et al. , 2002 ; Takahashi et al. , 2000 ) ."
      },

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1155,7 +1155,7 @@
       "sentence": "Surprisingly , we found that Foxk1 migration on SDS-PAGE in Tsc2-/- MEFs was dramatically decreased by rapamycin treatment within 30 min and was sustained for up to 24 hr            ."
      },
      {
-      "text": "calcium",
+      "text": "Ca2+",
       "xref_id": "29108",
       "namespace": "chebi",
       "sentence": "Both calcium ( Ca2+ ) flux and Ca2 +-dependent signaling play a crucial role in this process , although the underlying mechanism has yet to be elucidated ."

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -244,6 +244,7 @@
   },
   {
    "id": "http://dx.doi.org/10.1016/j.molcel.2016.12.018",
+   "organismOrdering": [4932, 559292],
    "entities": [
     {
       "text": "CDK2",

--- a/test/util/data/pc-blacklist.json
+++ b/test/util/data/pc-blacklist.json
@@ -4,7 +4,8 @@
       {
         "namespace": "chebi",
         "xref_id": "15378",
-        "text": "hydrogen"
+        "text": "hydrogen",
+        "loose": 8
       },
       {
         "namespace": "chebi",
@@ -29,7 +30,8 @@
       {
         "namespace": "chebi",
         "xref_id": "37565",
-        "text": "GTP"
+        "text": "GTP",
+        "loose": true
       },
       {
         "namespace": "chebi",
@@ -49,7 +51,8 @@
       {
         "namespace": "chebi",
         "xref_id": "18009",
-        "text": "NADP"
+        "text": "NADP",
+        "loose": true
       },
       {
         "namespace": "chebi",
@@ -60,7 +63,8 @@
       {
         "namespace": "chebi",
         "xref_id": "15846",
-        "text": "NAD"
+        "text": "NAD",
+        "loose": true
       },
       {
         "namespace": "chebi",
@@ -75,7 +79,7 @@
       },
       {
         "namespace": "chebi",
-        "xref_id": "58349",
+        "xref_id": "18009",
         "text": "NADP(+)"
       },
       {
@@ -90,7 +94,7 @@
       },
       {
         "namespace": "chebi",
-        "xref_id": "57540",
+        "xref_id": "15846",
         "text": "NAD(+)"
       },
       {
@@ -101,7 +105,8 @@
       {
         "namespace": "chebi",
         "xref_id": "57783",
-        "text": "NADPH"
+        "text": "NADPH",
+        "loose": true
       },
       {
         "namespace": "chebi",
@@ -116,16 +121,19 @@
       {
         "namespace": "chebi",
         "xref_id": "58307",
-        "text": "FADH2"
+        "text": "FADH2",
+        "loose": true
       },
       {
         "namespace": "chebi",
         "xref_id": "17877",
-        "text": "FADH2"
+        "text": "FADH2",
+        "loose": true
       },
       {
         "namespace": "chebi",
         "xref_id": "456216",
+        "loose": 5,
         "text": "ADP"
       },
       {

--- a/test/util/data/pc-blacklist.json
+++ b/test/util/data/pc-blacklist.json
@@ -54,7 +54,8 @@
       {
         "namespace": "chebi",
         "xref_id": "35780",
-        "text": "phosphate"
+        "text": "phosphate",
+        "loose": 5
       },
       {
         "namespace": "chebi",
@@ -64,7 +65,8 @@
       {
         "namespace": "chebi",
         "xref_id": "18367",
-        "text": "phosphate"
+        "text": "phosphate",
+        "loose": 5
       },
       {
         "namespace": "chebi",
@@ -129,7 +131,8 @@
       {
         "namespace": "chebi",
         "xref_id": "26078",
-        "text":"Phosphate"
+        "text":"Phosphate",
+        "loose": 5
       }
     ]
   }

--- a/test/util/data/top-ncbi-gene.json
+++ b/test/util/data/top-ncbi-gene.json
@@ -1068,6 +1068,7 @@
       {
         "text": "leptin",
         "xref_id": "25608",
+        "loose": true,
         "namespace": "ncbi",
         "sentence": null
       }

--- a/test/util/data/top-ncbi-gene.json
+++ b/test/util/data/top-ncbi-gene.json
@@ -857,6 +857,7 @@
       },
       {
         "text": "FLS2",
+        "loose": true,
         "xref_id": "834676",
         "namespace": "ncbi",
         "sentence": null

--- a/test/util/data/top-ncbi-gene.json
+++ b/test/util/data/top-ncbi-gene.json
@@ -1032,6 +1032,7 @@
       {
         "text": "p38",
         "xref_id": "81649",
+        "loose": true,
         "namespace": "ncbi",
         "sentence": null
       },

--- a/test/util/data/top-ncbi-gene.json
+++ b/test/util/data/top-ncbi-gene.json
@@ -1166,7 +1166,8 @@
         "text": "TNFalpha",
         "xref_id": "405785",
         "namespace": "ncbi",
-        "sentence": null
+        "sentence": null,
+        "loose": true
       },
       {
         "text": "dlx2a",


### PR DESCRIPTION
This covers some of the failures with the updates in ad5b7b600ae2ebf091886ba3e4e399fe619d2d88 and f5b6a5f761d744561ebbc8c45c3debc423dca643.

Most of these cases are just enabling the `loose` flag on cases that are inherently ambiguous.  By default, `loose: true` sets it so the test case passes if the expected result is in the top-3.  You can set a custom `loose: N` integer if you want to loosen the strictness further to the top-N.  That should only be done in special cases, and most should remain `loose: true`.

Some of the fixes are just typos.

Note: This doesn't review all of the failures.  I only got through part of them to see in what ways the search could be improved.

I added yeast variants to one of the yeast-specific papers, and that seemed to sort it out for that one.  The same should be applied to the others that are missing `organismOrdering`.