### PR TITLE
Grounded orgs for remaining papers

### DIFF
--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -2086,6 +2086,7 @@
   },
   {
    "id": "http://dx.doi.org/10.1016/j.molcel.2013.11.004",
+   "organismOrdering": [9606, 10090],
    "entities": [
     {
       "text": "LincRNA-p21",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1803,6 +1803,7 @@
   },
   {
    "id": "http://dx.doi.org/10.1016/j.molcel.2016.12.021",
+   "organismOrdering": [9606, 10090, 11320, 11588, 11191],
    "entities": [
     {
       "text": "RIG-I",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -337,6 +337,7 @@
   },
   {
    "id": "https://doi.org/10.1016/j.molcel.2018.04.024",
+   "organismOrdering": [10090, 9606],
    "entities": [
     {
       "text": "Foxk1",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -986,6 +986,7 @@
   },
   {
    "id": "https://doi.org/10.1016/j.molcel.2017.11.025",
+   "organismOrdering": [9606, 10090],
    "entities": [
     {
       "text": "cytochrome c",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1971,6 +1971,7 @@
   },
   {
    "id": "https://doi.org/10.1016/j.molcel.2011.01.014",
+   "organismOrdering": [10116],
    "entities": [
     {
       "text": "myc",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1,6 +1,7 @@
 [
   {
    "id": "http://dx.doi.org/10.1016/j.molcel.2017.01.019",
+   "organismOrdering": [9606],
    "entities": [
     {
      "text": "RUVBL1",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -535,6 +535,7 @@
   },
   {
    "id": "http://dx.doi.org/10.1016/j.molcel.2016.11.034",
+   "organismOrdering": [10090, 9606],
    "entities": [
     {
       "text": "p65",

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -241,6 +241,7 @@
   },
   {
    "id": "http://dx.doi.org/10.1016/j.molcel.2016.12.018",
+   "organismOrdering": [4932],
    "entities": [
     {
       "text": "CDK2",


### PR DESCRIPTION
I guess the first batch that I got was lucky. In this case, I found some sound scientifically but "don't know exactly what to do" grounding-wise papers. E.g. papers in which tumors grown in dishes from human cell lines get injected in vivo into mice. In these cases, I picked human as first organism, and mouse as second. In the case that the paper reported using viruses in essays, I appended the taxonomy id of the viruses as last ids in the array.