### PR TITLE
Appended entity tests for mol cell [online now]

### DIFF
--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -2231,5 +2231,126 @@
       "sentence": "( H ) GST-VHL proteins bound with glutathione agarose beads were incubated with purified recombinant Flag-HIF-1alpha in the presence or absence of in vitro transcribed lincRNA-p21 for 3 hr ."
      }
    ]
-  }
+  },
+  {
+    "id": "https://doi.org/10.1016/j.molcel.2019.03.023",
+    "organismOrdering": [10090],
+    "entities": [
+     {
+      "text": "ANKRD31", 
+      "namespace": "ncbi", 
+      "xref_id": "625662", 
+      "sentence": "REC114 Partner ANKRD31 Controls Number , Timing , and Location of Meiotic DNA Breaks  Michiel Boekhout , Mehmet E. Karasu , Juncheng Wang , Laurent Acquaviva , Florencia Pratto , Kevin Brick , Diana Y. Eng , Jiaqi Xu , R. Daniel Camerini-Otero , Dinshaw J. Patel , Scott Keeney  DOI : https://doi.org/10.1016/j.molcel.2019.03.023  Summary Double-strand breaks ( DSBs ) initiate the homologous recombination that is crucial for meiotic chromosome pairing and segregation ."
+     }, 
+     {
+      "text": "REC114", 
+      "namespace": "ncbi", 
+      "xref_id": "73673", 
+      "sentence": "REC114 Partner ANKRD31 Controls Number , Timing , and Location of Meiotic DNA Breaks  Michiel Boekhout , Mehmet E. Karasu , Juncheng Wang , Laurent Acquaviva , Florencia Pratto , Kevin Brick , Diana Y. Eng , Jiaqi Xu , R. Daniel Camerini-Otero , Dinshaw J. Patel , Scott Keeney  DOI : https://doi.org/10.1016/j.molcel.2019.03.023  Summary Double-strand breaks ( DSBs ) initiate the homologous recombination that is crucial for meiotic chromosome pairing and segregation ."
+     }, 
+     {
+      "text": "MEI4", 
+      "namespace": "ncbi", 
+      "xref_id": "75033", 
+      "sentence": "Results  ANKRD31 Is a Meiosis Specific REC114 Interactor We used mouse REC114 and MEI4 as baits in a yeast two-hybrid screen with a cDNA library from juvenile mouse testes ."
+     }, 
+     {
+      "text": "SYCP3", 
+      "namespace": "ncbi", 
+      "xref_id": "20962", 
+      "sentence": "Early in prophase I , aligned sister chromatids begin to form a synaptonemal complex protein 3 ( SYCP3 )-containing protein axis from which chromatin loops emanate ( leptonema ) ."
+     }, 
+     {
+      "text": "IHO1", 
+      "namespace": "ncbi", 
+      "xref_id": "434438", 
+      "sentence": "ANKRD31 also colocalizes with MEI4 , MEI1 , and IHO1 ( Acquaviva et al. , 2019 ) ."
+     }, 
+     {
+      "text": "MEI1", 
+      "namespace": "ncbi", 
+      "xref_id": "74369", 
+      "sentence": "ANKRD31 also colocalizes with MEI4 , MEI1 , and IHO1 ( Acquaviva et al. , 2019 ) ."
+     }, 
+     {
+      "text": "SYCP1", 
+      "namespace": "ncbi", 
+      "xref_id": "20957", 
+      "sentence": "We tracked synapsis by immunostaining for SYCP3 and the SC central region protein SYCP1 ( de Vries et al. , 2005 ) ."
+     }, 
+     {
+      "text": "DMC1", 
+      "namespace": "ncbi", 
+      "xref_id": "13404", 
+      "sentence": "To assess recombination , we immunostained chromosomes for RAD51 and DMC1                              ."
+     }, 
+     {
+      "text": "RAD51", 
+      "namespace": "ncbi", 
+      "xref_id": "19361", 
+      "sentence": "To assess recombination , we immunostained chromosomes for RAD51 and DMC1                              ."
+     }, 
+     {
+      "text": "RPA", 
+      "namespace": null, 
+      "xref_id": null, 
+      "sentence": "Earlier-stage cells also had fewer foci of the single stranded DNA ( ssDNA )-binding replication protein A ( RPA )                     ."
+     }, 
+     {
+      "text": "histone H2AX", 
+      "namespace": "ncbi", 
+      "xref_id": "15270", 
+      "sentence": "We also examined the phosphorylation of histone H2AX ( gammaH2AX ) , which is formed rapidly by ATM in response to DSBs and then disappears progressively as recombination proceeds until it is largely gone from autosomes in pachynema             ( Mahadevaiah et al. , 2001 , Barchi et al. , 2005 ) ."
+     }, 
+     {
+      "text": "gammaH2AX", 
+      "namespace": "ncbi", 
+      "xref_id": "15270", 
+      "sentence": "We also examined the phosphorylation of histone H2AX ( gammaH2AX ) , which is formed rapidly by ATM in response to DSBs and then disappears progressively as recombination proceeds until it is largely gone from autosomes in pachynema             ( Mahadevaiah et al. , 2001 , Barchi et al. , 2005 ) ."
+     }, 
+     {
+      "text": "ATM", 
+      "namespace": "ncbi", 
+      "xref_id": "11920", 
+      "sentence": "We also examined the phosphorylation of histone H2AX ( gammaH2AX ) , which is formed rapidly by ATM in response to DSBs and then disappears progressively as recombination proceeds until it is largely gone from autosomes in pachynema             ( Mahadevaiah et al. , 2001 , Barchi et al. , 2005 ) ."
+     }, 
+     {
+      "text": "MLH1", 
+      "namespace": "ncbi", 
+      "xref_id": "17350", 
+      "sentence": "By comparison , autosomes showed only a modest defect : pachytene cells with complete autosome synapsis had a small increase in the number of MLH1 foci ( means of 23.7 in wild type and 24.8 in Ankrd31-/-; Figure 4E ) ."
+     }, 
+     {
+      "text": "PRDM9", 
+      "namespace": "ncbi", 
+      "xref_id": "213389", 
+      "sentence": "PAR DSBs are largely independent of PRDM9 ( Brick et al. , 2012 )             and have other requirements that are distinct from autosomes ( Kauppi et al. , 2011 , Smagulova et al. , 2013 ) , so a PAR defect does not predict that SPO11 targeting to PRDM9 sites would be affected ."
+     }, 
+     {
+      "text": "SPO11", 
+      "namespace": "ncbi", 
+      "xref_id": "26972", 
+      "sentence": "PAR DSBs are largely independent of PRDM9 ( Brick et al. , 2012 )             and have other requirements that are distinct from autosomes ( Kauppi et al. , 2011 , Smagulova et al. , 2013 ) , so a PAR defect does not predict that SPO11 targeting to PRDM9 sites would be affected ."
+     },
+     {
+      "text": "CARM1", 
+      "namespace": "ncbi", 
+      "xref_id": "59035", 
+      "sentence": "A structural homology search revealed that REC114N is similar to the N-terminal domain of coactivator associated methyltransferase 1 ( CARM1 ) ( Troffer-Charlier et al. , 2007 ) , which belongs to the PH domain superfamily ."
+     },
+     {
+      "text": "ammonium", 
+      "namespace": "chebi", 
+      "xref_id": "28938", 
+      "sentence": "The aromatic ring of W1857 also forms a cation-pi interaction by packing against the ammonium group of R117 and the aromatic side chain of invariant W51 from REC114N ."
+     }, 
+     {
+      "text": "hematoxylin", 
+      "namespace": "chebi", 
+      "xref_id": "51686", 
+      "sentence": "Images show adult ( 4 months ) testis sections stained with TUNEL and hematoxylin ."
+     }
+    ]
+   }
+
  ]

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -2236,121 +2236,256 @@
     "id": "https://doi.org/10.1016/j.molcel.2019.03.023",
     "organismOrdering": [10090],
     "entities": [
-     {
+    {
       "text": "ANKRD31", 
       "namespace": "ncbi", 
       "xref_id": "625662", 
       "sentence": "REC114 Partner ANKRD31 Controls Number , Timing , and Location of Meiotic DNA Breaks  Michiel Boekhout , Mehmet E. Karasu , Juncheng Wang , Laurent Acquaviva , Florencia Pratto , Kevin Brick , Diana Y. Eng , Jiaqi Xu , R. Daniel Camerini-Otero , Dinshaw J. Patel , Scott Keeney  DOI : https://doi.org/10.1016/j.molcel.2019.03.023  Summary Double-strand breaks ( DSBs ) initiate the homologous recombination that is crucial for meiotic chromosome pairing and segregation ."
-     }, 
-     {
+    }, 
+    {
       "text": "REC114", 
       "namespace": "ncbi", 
       "xref_id": "73673", 
       "sentence": "REC114 Partner ANKRD31 Controls Number , Timing , and Location of Meiotic DNA Breaks  Michiel Boekhout , Mehmet E. Karasu , Juncheng Wang , Laurent Acquaviva , Florencia Pratto , Kevin Brick , Diana Y. Eng , Jiaqi Xu , R. Daniel Camerini-Otero , Dinshaw J. Patel , Scott Keeney  DOI : https://doi.org/10.1016/j.molcel.2019.03.023  Summary Double-strand breaks ( DSBs ) initiate the homologous recombination that is crucial for meiotic chromosome pairing and segregation ."
-     }, 
-     {
+    }, 
+    {
       "text": "MEI4", 
       "namespace": "ncbi", 
       "xref_id": "75033", 
       "sentence": "Results  ANKRD31 Is a Meiosis Specific REC114 Interactor We used mouse REC114 and MEI4 as baits in a yeast two-hybrid screen with a cDNA library from juvenile mouse testes ."
-     }, 
-     {
+    }, 
+    {
       "text": "SYCP3", 
       "namespace": "ncbi", 
       "xref_id": "20962", 
       "sentence": "Early in prophase I , aligned sister chromatids begin to form a synaptonemal complex protein 3 ( SYCP3 )-containing protein axis from which chromatin loops emanate ( leptonema ) ."
-     }, 
-     {
+    }, 
+    {
       "text": "IHO1", 
       "namespace": "ncbi", 
       "xref_id": "434438", 
       "sentence": "ANKRD31 also colocalizes with MEI4 , MEI1 , and IHO1 ( Acquaviva et al. , 2019 ) ."
-     }, 
-     {
+    }, 
+    {
       "text": "MEI1", 
       "namespace": "ncbi", 
       "xref_id": "74369", 
       "sentence": "ANKRD31 also colocalizes with MEI4 , MEI1 , and IHO1 ( Acquaviva et al. , 2019 ) ."
-     }, 
-     {
+    }, 
+    {
       "text": "SYCP1", 
       "namespace": "ncbi", 
       "xref_id": "20957", 
       "sentence": "We tracked synapsis by immunostaining for SYCP3 and the SC central region protein SYCP1 ( de Vries et al. , 2005 ) ."
-     }, 
-     {
+    }, 
+    {
       "text": "DMC1", 
       "namespace": "ncbi", 
       "xref_id": "13404", 
       "sentence": "To assess recombination , we immunostained chromosomes for RAD51 and DMC1                              ."
-     }, 
-     {
+    }, 
+    {
       "text": "RAD51", 
       "namespace": "ncbi", 
       "xref_id": "19361", 
       "sentence": "To assess recombination , we immunostained chromosomes for RAD51 and DMC1                              ."
-     }, 
-     {
+    }, 
+    {
       "text": "RPA", 
       "namespace": null, 
       "xref_id": null, 
       "sentence": "Earlier-stage cells also had fewer foci of the single stranded DNA ( ssDNA )-binding replication protein A ( RPA )                     ."
-     }, 
-     {
+    }, 
+    {
       "text": "histone H2AX", 
       "namespace": "ncbi", 
       "xref_id": "15270", 
       "sentence": "We also examined the phosphorylation of histone H2AX ( gammaH2AX ) , which is formed rapidly by ATM in response to DSBs and then disappears progressively as recombination proceeds until it is largely gone from autosomes in pachynema             ( Mahadevaiah et al. , 2001 , Barchi et al. , 2005 ) ."
-     }, 
-     {
+    }, 
+    {
       "text": "gammaH2AX", 
       "namespace": "ncbi", 
       "xref_id": "15270", 
       "sentence": "We also examined the phosphorylation of histone H2AX ( gammaH2AX ) , which is formed rapidly by ATM in response to DSBs and then disappears progressively as recombination proceeds until it is largely gone from autosomes in pachynema             ( Mahadevaiah et al. , 2001 , Barchi et al. , 2005 ) ."
-     }, 
-     {
+    }, 
+    {
       "text": "ATM", 
       "namespace": "ncbi", 
       "xref_id": "11920", 
       "sentence": "We also examined the phosphorylation of histone H2AX ( gammaH2AX ) , which is formed rapidly by ATM in response to DSBs and then disappears progressively as recombination proceeds until it is largely gone from autosomes in pachynema             ( Mahadevaiah et al. , 2001 , Barchi et al. , 2005 ) ."
-     }, 
-     {
-      "text": "MLH1", 
+    }, 
+    {
+    "text": "MLH1", 
       "namespace": "ncbi", 
       "xref_id": "17350", 
       "sentence": "By comparison , autosomes showed only a modest defect : pachytene cells with complete autosome synapsis had a small increase in the number of MLH1 foci ( means of 23.7 in wild type and 24.8 in Ankrd31-/-; Figure 4E ) ."
-     }, 
-     {
+    }, 
+    {
       "text": "PRDM9", 
       "namespace": "ncbi", 
       "xref_id": "213389", 
       "sentence": "PAR DSBs are largely independent of PRDM9 ( Brick et al. , 2012 )             and have other requirements that are distinct from autosomes ( Kauppi et al. , 2011 , Smagulova et al. , 2013 ) , so a PAR defect does not predict that SPO11 targeting to PRDM9 sites would be affected ."
-     }, 
-     {
+    }, 
+    {
       "text": "SPO11", 
       "namespace": "ncbi", 
       "xref_id": "26972", 
       "sentence": "PAR DSBs are largely independent of PRDM9 ( Brick et al. , 2012 )             and have other requirements that are distinct from autosomes ( Kauppi et al. , 2011 , Smagulova et al. , 2013 ) , so a PAR defect does not predict that SPO11 targeting to PRDM9 sites would be affected ."
-     },
-     {
+    },
+    {
       "text": "CARM1", 
       "namespace": "ncbi", 
       "xref_id": "59035", 
       "sentence": "A structural homology search revealed that REC114N is similar to the N-terminal domain of coactivator associated methyltransferase 1 ( CARM1 ) ( Troffer-Charlier et al. , 2007 ) , which belongs to the PH domain superfamily ."
-     },
-     {
+    },
+    {
       "text": "ammonium", 
       "namespace": "chebi", 
       "xref_id": "28938", 
       "sentence": "The aromatic ring of W1857 also forms a cation-pi interaction by packing against the ammonium group of R117 and the aromatic side chain of invariant W51 from REC114N ."
-     }, 
-     {
+    }, 
+    {
       "text": "hematoxylin", 
       "namespace": "chebi", 
       "xref_id": "51686", 
       "sentence": "Images show adult ( 4 months ) testis sections stained with TUNEL and hematoxylin ."
-     }
-    ]
-   }
-
+    }]
+  },
+  {
+    "id": "https://doi.org/10.1016/j.molcel.2019.03.033",
+    "organismOrdering": [9606],
+    "entities": [
+    {
+      "text": "TEX264", 
+      "namespace": "ncbi", 
+      "xref_id": "51368", 
+      "sentence": "Intrinsically Disordered Protein TEX264 Mediates ER-phagy  Haruka Chino , Tomohisa Hatta , Tohru Natsume , Noboru Mizushima  DOI : https://doi.org/10.1016/j.molcel.2019.03.033  Summary Certain proteins and organelles can be selectively degraded by autophagy ."
+    }, 
+    {
+      "text": "ER", 
+      "namespace": null, 
+      "xref_id": null, 
+      "sentence": "TEX264 is an ER protein with a single transmembrane domain and a LIR motif ."
+    }, 
+    {
+      "text": "CCPG1", 
+      "namespace": "ncbi", 
+      "xref_id": "9236", 
+      "sentence": "ER-phagy is profoundly blocked by deletion of TEX264 alone and almost completely by additional deletion of FAM134B and CCPG1 ."
+    }, 
+    {
+      "text": "FAM134B", 
+      "namespace": "ncbi", 
+      "xref_id": "54463", 
+      "sentence": "ER-phagy is profoundly blocked by deletion of TEX264 alone and almost completely by additional deletion of FAM134B and CCPG1 ."
+    }, 
+    {
+      "text": "LC3B", 
+      "namespace": "ncbi", 
+      "xref_id": "81631", 
+      "sentence": "Results To identify novel substrates and receptors of selective autophagy , we searched for proteins that interacted with LC3B in a LIR dependent manner ."
+    }, 
+    {
+      "text": "p62", 
+      "namespace": "ncbi", 
+      "xref_id": "8878", 
+      "sentence": "As a positive control , p62 ( also known as SQSTM1 ) was detected as one of the top candidates                      ."
+    }, 
+    {
+      "text": "SQSTM1", 
+      "namespace": "ncbi", 
+      "xref_id": "8878", 
+      "sentence": "As a positive control , p62 ( also known as SQSTM1 ) was detected as one of the top candidates                      ."
+    }, 
+    {
+      "text": "cytochrome b5", 
+      "namespace": "ncbi", 
+      "xref_id": "1528", 
+      "sentence": "TEX264-GFP showed a reticular pattern under nutrient rich conditions and colocalized with the ER marker cytochrome b5            ."
+    }, 
+    {
+      "text": "FIP200", 
+      "namespace": "ncbi", 
+      "xref_id": "9821", 
+      "sentence": "Most of these structures colocalized with the autophagosomal protein LC3                    , as well as the isolation membrane proteins FIP200 and WIPI2            ."
+    }, 
+    {
+      "text": "WIPI2", 
+      "namespace": "ncbi", 
+      "xref_id": "26100", 
+      "sentence": "Most of these structures colocalized with the autophagosomal protein LC3                    , as well as the isolation membrane proteins FIP200 and WIPI2            ."
+    }, 
+    {
+      "text": "bafilomycin A1", 
+      "namespace": "chebi", 
+      "xref_id": "22689", 
+      "sentence": "The number of theseTEX264 structures increased following bafilomycin A1 treatment , suggesting that TEX264 is delivered to lysosomes                    ."
+    }, 
+    {
+      "text": "LAMP1", 
+      "namespace": "ncbi", 
+      "xref_id": "3916", 
+      "sentence": "In fact , some of the TEX264 positive puncta colocalized with LAMP1 under starvation conditions            ."
+    }, 
+    {
+      "text": "doxycycline", 
+      "namespace": "chebi", 
+      "xref_id": "50845", 
+      "sentence": "We developed a doxycycline inducible ER-phagy reporter that has an N-terminal ER signal sequence followed by tandem monomeric RFP and GFP sequences and the ER retention sequence KDEL            ."
+    }, 
+    {
+      "text": "SEC62", 
+      "namespace": "ncbi", 
+      "xref_id": "7095", 
+      "sentence": "TEX264 Is a Major ER-phagy Receptor To date , four ER-phagy receptors , namely , FAM134B , CCPG1 , RTN3L , and SEC62 , have been reported in mammals ( Fumagalli et al. , 2016 , Grumati et al. , 2017 , Grumati et al. , 2018 , Khaminets et al. , 2015 , Smith et al. , 2018 ) ."
+    }, 
+    {
+      "text": "RTN3", 
+      "namespace": "ncbi", 
+      "xref_id": "10313", 
+      "sentence": "Simultaneous depletion of FAM134B , CCPG1 , RTN3 , and SEC62 ( not TEX264 ) caused a partial reduction in the cleavage of the ER-phagy reporter under basal and starvation conditions , but a significant level ( > 50 % ) of ER-phagy activity remained                                    ."
+    }, 
+    {
+      "text": "GABARAPL1", 
+      "namespace": "ncbi", 
+      "xref_id": "23710", 
+      "sentence": "TEX264 interacted strongly with LC3A , GABARAP , and GABARAPL1 ."
+    }, 
+    {
+      "text": "GABARAP", 
+      "namespace": "ncbi", 
+      "xref_id": "11337", 
+      "sentence": "TEX264 interacted strongly with LC3A , GABARAP , and GABARAPL1 ."
+    }, 
+    {
+      "text": "LC3A", 
+      "namespace": "ncbi", 
+      "xref_id": "84557", 
+      "sentence": "TEX264 interacted strongly with LC3A , GABARAP , and GABARAPL1 ."
+    }, 
+    {
+      "text": "RTN4", 
+      "namespace": "ncbi", 
+      "xref_id": "57142", 
+      "sentence": "However , it might reflect a change in ER distribution rather than an increase in ER volume , because no significant change in the amount of ER resident proteins such as RTN4 was detected in TEX264-KO and triple-KO cells by immunoblotting             ."
+    }, 
+    {
+      "text": "ATG13", 
+      "namespace": "ncbi", 
+      "xref_id": "9776", 
+      "sentence": "When we inserted an IDR sequence from human ATG13 ( amino acids 191-248 ) corresponding to the previously characterized IDR region in yeast Atg13 ( Yamamoto et al. , 2016 ) , LC3 colocalization was rescued                    ."
+    }, 
+    {
+      "text": "Cytb5", 
+      "namespace": "ncbi", 
+      "xref_id": "1528", 
+      "sentence": "Figure 2 TEX264 Is Present in the ER and Colocalizes with Autophagosomes Hide caption ( A ) MEFs stably expressing TEX264-GFP and mRuby3-cytochrom b5 ( Cytb5 ) were directly observed by fluorescence microscopy ."
+    }, 
+    {
+      "text": "Atg5", 
+      "namespace": "ncbi", 
+      "xref_id": "9474", 
+      "sentence": "( C and D ) Immunoblotting of endogenous TEX264 ( and other ER-phagy receptors ) in postnuclear supernatants of brains from three independent Fip200f/+ ; nestin-CRE ( Ctrl ) and Fip200f/f ; nestin-CRE ( neuro-KO ) mice ( C ) and the indicated organs from Atg5 +/+ ; NSE-Atg5 ( +/+ ) and Atg5-/-; NSE-Atg5 ( KO ) mice ( D ) ."
+    }]
+  }
  ]


### PR DESCRIPTION
Article test for 
  - [Boekhout et al. Mol. Cell, April 16, 2019, REC114 Partner ANKRD31 Controls Number, Timing, and Location of Meiotic DNA Breaks](https://www.cell.com/molecular-cell/fulltext/S1097-2765(19)30227-8).
- [Chino et al. Mol. Cell, June 6, 2019, Intrinsically Disordered Protein TEX264 Mediates ER-phagy](https://www.cell.com/molecular-cell/fulltext/S1097-2765(19)30257-6).