### PR TITLE
Update NCBI datasource to give `type: 'ggp'`

### DIFF
--- a/src/server/datasource/ncbi.js
+++ b/src/server/datasource/ncbi.js
@@ -14,7 +14,7 @@ import ROOT_STRAINS from './strains/root';
 
 const FILE_PATH = path.join(INPUT_PATH, NCBI_FILE_NAME);
 const ENTRY_NS = 'ncbi';
-const ENTRY_TYPE = 'protein';
+const ENTRY_TYPE = 'ggp';
 const NODE_DELIMITER = '\t';
 const EMPTY_VALUE = '-';
 const DEFAULT_SCROLL = '10s';

--- a/test/ncbi.js
+++ b/test/ncbi.js
@@ -219,7 +219,7 @@ describe(`merge strains ${namespace}`, function(){
   let testEntries = [
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '39537837',
       'organism': '562',
       'name': 'ccdB',
@@ -229,7 +229,7 @@ describe(`merge strains ${namespace}`, function(){
     },
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '39537837-2',
       'organism': '562',
       'name': 'ccdB',
@@ -239,7 +239,7 @@ describe(`merge strains ${namespace}`, function(){
     },
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '18252830',
       'organism': '1311757',
       'name': 'ccdB',
@@ -249,7 +249,7 @@ describe(`merge strains ${namespace}`, function(){
     },
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '8164769',
       'organism': '563770',
       'name': 'ccdB',
@@ -259,7 +259,7 @@ describe(`merge strains ${namespace}`, function(){
     },
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '9292836',
       'organism': '762608',
       'name': 'ccdB',
@@ -273,7 +273,7 @@ describe(`merge strains ${namespace}`, function(){
   let singleSynonymEntries = [
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '1',
       'organism': '562',
       'name': 'A',
@@ -283,7 +283,7 @@ describe(`merge strains ${namespace}`, function(){
     },
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '2',
       'organism': '562',
       'name': 'B',
@@ -293,7 +293,7 @@ describe(`merge strains ${namespace}`, function(){
     },
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '3',
       'organism': '562',
       'name': 'B',
@@ -302,7 +302,7 @@ describe(`merge strains ${namespace}`, function(){
     },
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '4',
       'organism': '562',
       'name': 'C',
@@ -312,7 +312,7 @@ describe(`merge strains ${namespace}`, function(){
     },
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '5',
       'organism': '562',
       'name': 'D',
@@ -321,7 +321,7 @@ describe(`merge strains ${namespace}`, function(){
     },
     {
       'namespace': 'ncbi',
-      'type': 'protein',
+      'type': 'ggp',
       'id': '6',
       'organism': '562',
       'name': 'd',


### PR DESCRIPTION
This revises groundings from NCBI to have the default type 'ggp' (gene or gene product).  Apps such as Factoid can refine the type to things like 'protein' based on user input.

Ref : Rename `type:'protein'` #44