### PR TITLE
SARS-Cov-2 Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2453,7 +2453,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2477,13 +2478,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2500,19 +2503,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2643,7 +2649,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2657,6 +2664,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2673,6 +2681,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2681,13 +2690,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2708,6 +2719,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2796,7 +2808,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2810,6 +2823,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2905,7 +2919,8 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2947,6 +2962,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2968,6 +2984,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3016,13 +3033,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4516,6 +4535,11 @@
           "dev": true
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "nodemon": {
       "version": "1.18.10",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ftp": "^0.3.10",
     "lodash": "^4.17.11",
     "morgan": "^1.7.0",
+    "node-fetch": "^2.6.0",
     "saxes": "^3.1.9",
     "serve-favicon": "^2.3.0",
     "split": "^1.0.1",

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -38,3 +38,6 @@ export const CHEBI_URL = env('CHEBI_URL', 'ftp://ftp.ebi.ac.uk/pub/databases/che
 
 export const NCBI_FILE_NAME = env('NCBI_FILE_NAME', 'ncbi');
 export const NCBI_URL = env('NCBI_URL', 'ftp://ftp.ncbi.nih.gov/gene/DATA/gene_info.gz');
+export const NCBI_EUTILS_BASE_URL = env('NCBI_EUTILS_BASE_URL', 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/');
+export const NCBI_EUTILS_API_KEY = env('NCBI_EUTILS_API_KEY', 'b99e10ebe0f90d815a7a99f18403aab08008');
+

--- a/src/server/datasource/eutils.js
+++ b/src/server/datasource/eutils.js
@@ -1,0 +1,116 @@
+import _ from 'lodash';
+import queryString from 'query-string';
+import fetch from 'node-fetch';
+import { NCBI_EUTILS_BASE_URL, NCBI_EUTILS_API_KEY } from '../config';
+
+const checkHTTPStatus = response => {
+  const { statusText, status, ok } = response;
+  if ( !ok ) {
+    throw new Error( `${statusText} (${status})`, status, statusText );
+  }
+  return response;
+};
+
+const checkEsummaryResult = json => {
+  const errorMessage =  _.get( json, ['esummaryresult', '0'] );
+  if( errorMessage ) throw new Error( errorMessage );
+  return json;
+};
+
+const checkEsearchResult = json => {
+  const errorMessage =  _.get( json, ['esearchresult', 'ERROR'] );
+  if( errorMessage ) throw new Error( errorMessage );
+  return json;
+};
+
+const EUTILS_ESUMMARY_URL = NCBI_EUTILS_BASE_URL + 'esummary.fcgi';
+const DEFAULT_ESUMMARY_PARAMS = {
+  id: undefined,
+  db: 'protein',
+  retstart: 1,
+  retmode: 'json',
+  retmax: 10000,
+  query_key: undefined,
+  WebEnv: undefined,
+  api_key: NCBI_EUTILS_API_KEY
+};
+
+/**
+ * eSummary
+ * Wrapper for the ESUMMARY EUTILITY {@link https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESummary|ESUMMARY docs }
+ *
+ * @param { Object } opts EUTILS ESUMMARY options
+ * @returns { Object } The esearch results
+ * @throws { Error } based on HTTP status and ESUMMARY result
+ */
+const eSummary = opts => {
+  const params = _.assign( {}, DEFAULT_ESUMMARY_PARAMS, opts );
+  const url = EUTILS_ESUMMARY_URL + '?' + queryString.stringify( params );
+  const userAgent = `${process.env.npm_package_name}/${process.env.npm_package_version}`;
+  return fetch( url, {
+    method: 'GET',
+    headers: {
+      'User-Agent': userAgent
+    }
+  })
+    .then( checkHTTPStatus ) // HTTPStatusError
+    .then( response => response.json() )
+    .then( checkEsummaryResult ); // Error (programmatic)
+};
+
+const EUTILS_SEARCH_URL = NCBI_EUTILS_BASE_URL + 'esearch.fcgi';
+const DEFAULT_ESEARCH_PARAMS = {
+  term: undefined,
+  db: 'protein',
+  rettype: 'uilist',
+  retmode: 'json',
+  retmax: 10000,
+  usehistory: 'y',
+  field: undefined,
+  idtype: undefined,
+  api_key: NCBI_EUTILS_API_KEY
+};
+
+/**
+ * eSearch
+ * Wrapper for the ESEARCH EUTILITY {@link https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch|EUTILS docs }
+ *
+ * @param { Object } opts EUTILS ESEARCH options
+ * @returns { Object } The esearch results
+ * @throws { Error } based on HTTP status and ESEARCH result
+ */
+const eSearch = opts => {
+  const params = _.assign( {}, DEFAULT_ESEARCH_PARAMS, opts );
+  const url = EUTILS_SEARCH_URL + '?' + queryString.stringify( params );
+  const userAgent = `${process.env.npm_package_name}/${process.env.npm_package_version}`;
+  return fetch( url, {
+    method: 'GET',
+    headers: {
+      'User-Agent': userAgent
+    }
+  })
+    .then( checkHTTPStatus ) // HTTPStatusError
+    .then( response => response.json() )
+    .then( checkEsearchResult ); // Error (programmatic)
+};
+
+/**
+ * eSearchSummaries
+ * Wrapper for piping  ESEARCH result into ESUMMARY
+ *
+ * @param { Object } opts EUTILS ESEARCH options
+ * @returns { Object } The eSummary results
+ * @throws { Error } based on HTTP status and ESEARCH/ESUMMARY result
+ */
+const eSearchSummaries = opts => {
+  const pickHhistoryOpts = eutilResponse => {
+    const esearchresult = _.get( eutilResponse, ['esearchresult'] );
+    return _.pick(  esearchresult, ['querykey', 'webenv'] );
+  };
+
+  return eSearch( opts )
+    .then( pickHhistoryOpts )
+    .then( ({ webenv, querykey }) => eSummary({ query_key: querykey, WebEnv: webenv }) );
+};
+
+export { eSearch, eSummary, eSearchSummaries };

--- a/src/server/datasource/ncbi.js
+++ b/src/server/datasource/ncbi.js
@@ -8,9 +8,10 @@ import { db } from '../db';
 import { seqPromise } from '../util';
 import DelimitedParser from '../parser/delimited-parser';
 import downloadFile from './download';
-import { updateEntriesFromFile } from './processing';
+import { updateEntriesFromFile, updateEntriesFromSource } from './processing';
 import { getOrganismById, isSupportedOrganism } from './organisms';
 import ROOT_STRAINS from './strains/root';
+import { eSearchSummaries } from './eutils';
 
 const FILE_PATH = path.join(INPUT_PATH, NCBI_FILE_NAME);
 const ENTRY_NS = 'ncbi';
@@ -18,6 +19,7 @@ const ENTRY_TYPE = 'ggp';
 const NODE_DELIMITER = '\t';
 const EMPTY_VALUE = '-';
 const DEFAULT_SCROLL = '10s';
+const TAX_ID_SARSCOV2 = 2697049;
 
 const NODE_INDICES = Object.freeze({
   ORGANISM: 0,
@@ -95,6 +97,40 @@ const parseFile = (filePath, onData, onEnd) => {
 
 const updateFromFile = () => updateEntriesFromFile(ENTRY_NS, FILE_PATH, parseFile, processEntry, includeEntry);
 
+const getProteinsByTaxon = tax_id => {
+  const opts = {
+    term: `txid${tax_id}[Organism:noexp] AND refseq[filter]`
+  };
+
+  const processProteinEntry = entry => {
+    const namespace = ENTRY_NS;
+    const type = 'protein';
+    const id = _.get( entry, 'uid' );
+    const organism = _.get( entry, 'taxid' );
+    const organismName = getOrganismById( organism ).name;
+    const name = _.get( entry, 'title' );
+    const synonyms = name.split(' '); // ?
+    const dbXrefs = [];
+    const typeOfGene = 'protein-coding';
+    return { namespace, type, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
+  };
+
+
+  const summary2Record = eSummaryResponse => {
+    const result = _.get( eSummaryResponse, ['result'] );
+    const uids = _.get( result, ['uids'] );
+    return uids.map( uid => {
+      const entry = _.get( result, uid );
+      return processProteinEntry( entry );
+    });
+  };
+
+  return eSearchSummaries( opts )
+    .then( summary2Record );
+};
+
+const updateOrganismProteins = tax_id => getProteinsByTaxon( tax_id ).then( entries => updateEntriesFromSource( ENTRY_NS, entries ) );
+
 /**
  * Downloads the 'ncbi' entities and stores them in the input file.
  * @returns {Promise} A promise that is resolved when the download is done.
@@ -104,11 +140,14 @@ const download = function(){
 };
 
 /**
- * Update the 'ncbi' entities in the index from the input file.
+ * Update the 'ncbi' entities
  * @returns {Promise} A promise that is resolved when the indexing is done.
  */
 const index = function(){
-  return updateFromFile();
+  return Promise.all([
+    updateFromFile(),
+    updateOrganismProteins( TAX_ID_SARSCOV2 )
+  ]);
 };
 
 /**

--- a/src/server/datasource/organisms.js
+++ b/src/server/datasource/organisms.js
@@ -50,7 +50,8 @@ const SORTED_MAIN_ORGANISMS = [
   new Organism(6239, 'Caenorhabditis elegans'),
   new Organism(3702, 'Arabidopsis thaliana'),
   new Organism(10116, 'Rattus norvegicus'),
-  new Organism(7955, 'Danio rerio')
+  new Organism(7955, 'Danio rerio'),
+  new Organism(2697049, 'SARS-CoV-2'),
 ];
 
 export const OTHER = new Organism(-1, 'Other');

--- a/src/server/datasource/processing.js
+++ b/src/server/datasource/processing.js
@@ -129,24 +129,31 @@ const updateEntriesFromFile = function(ns, filePath, parse, processEntry, includ
 
 /**
  * Update entries of a namespace directly
+ * Usage restricted to tiny datasets (order of CHUNK_SIZE)
+ *
  * @param {string} ns The namespace whose entries will be updated.
- * @param {object} entries The entries to insert
+ * @param {object} data The raw data to parse
+ * @param {object} parse The function to parse data into an array of entries
  * @param {function} processEntry A function that will be called to process entry data
  * before inserting it to database.
  * @param {function} [includeEntry = () => true] A function called to decide whether to include or omit an entry.
  */
-const updateEntriesFromSource = function( ns, entries ){
-  const manualRefresh = () => db.refreshIndex();
-  return db.insertEntries( entries, false ).then( res => {
-    if( res.errors ){
-      let err = new Error('Entries failed to be inserted');
-      err.response = res;
+const updateEntriesFromSource = async ( ns, data, parse, processEntry, includeEntry = () => true ) => {
+
+  const insertEntries = async entries => {
+    const insertResponse = await db.insertEntries( entries, false );
+    if( insertResponse.errors ){
+      let err = new Error('Failed to insert entries from source');
+      err.response = insertResponse;
       throw err;
     }
-    return res;
-  })
-    .then( () => logger.info(`Finished updating ${ns} data from source`) )
-    .then( manualRefresh );
+    return insertResponse;
+  };
+
+  const entries = parse( data ).filter( includeEntry ).map( processEntry );
+  await insertEntries( entries );
+  await db.refreshIndex();
+  logger.info(`Finished updating ${ns} data from source`);
 };
 
 export { updateEntriesFromFile, updateEntriesFromSource };

--- a/src/server/datasource/processing.js
+++ b/src/server/datasource/processing.js
@@ -127,4 +127,26 @@ const updateEntriesFromFile = function(ns, filePath, parse, processEntry, includ
   } );
 };
 
-export { updateEntriesFromFile };
+/**
+ * Update entries of a namespace directly
+ * @param {string} ns The namespace whose entries will be updated.
+ * @param {object} entries The entries to insert
+ * @param {function} processEntry A function that will be called to process entry data
+ * before inserting it to database.
+ * @param {function} [includeEntry = () => true] A function called to decide whether to include or omit an entry.
+ */
+const updateEntriesFromSource = function( ns, entries ){
+  const manualRefresh = () => db.refreshIndex();
+  return db.insertEntries( entries, false ).then( res => {
+    if( res.errors ){
+      let err = new Error('Entries failed to be inserted');
+      err.response = res;
+      throw err;
+    }
+    return res;
+  })
+    .then( () => logger.info(`Finished updating ${ns} data from source`) )
+    .then( manualRefresh );
+};
+
+export { updateEntriesFromFile, updateEntriesFromSource };

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -50,26 +50,4 @@ router.post('/get', function(req, res){
   aggregate.get(namespace, id).then(searchRes => res.json(searchRes));
 });
 
-// DEBUG
-router.post('/esearch', function(req, res, next){
-  const { term } = req.body;
-  eSearch({ term })
-    .then( data => res.json( data ) )
-    .catch( next );
-});
-
-router.post('/esummary', function(req, res, next){
-  const opts = req.body;
-  eSummary(opts)
-    .then( data => res.json( data ) )
-    .catch( next );
-});
-
-router.post('/esearchsummaries', function(req, res, next){
-  const opts = req.body;
-  eSearchSummaries(opts)
-    .then( data => res.json( data ) )
-    .catch( next );
-});
-
 export default router;

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,6 +1,5 @@
 import express from 'express';
 import { aggregate } from '../datasource/aggregate';
-import { eSearch, eSummary, eSearchSummaries } from '../datasource/eutils';
 
 const router = express.Router();
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { aggregate } from '../datasource/aggregate';
+import { eSearch, eSummary, eSearchSummaries } from '../datasource/eutils';
 
 const router = express.Router();
 
@@ -47,6 +48,28 @@ router.post('/get', function(req, res){
   const { namespace, id } = req.body;
 
   aggregate.get(namespace, id).then(searchRes => res.json(searchRes));
+});
+
+// DEBUG
+router.post('/esearch', function(req, res, next){
+  const { term } = req.body;
+  eSearch({ term })
+    .then( data => res.json( data ) )
+    .catch( next );
+});
+
+router.post('/esummary', function(req, res, next){
+  const opts = req.body;
+  eSummary(opts)
+    .then( data => res.json( data ) )
+    .catch( next );
+});
+
+router.post('/esearchsummaries', function(req, res, next){
+  const opts = req.body;
+  eSearchSummaries(opts)
+    .then( data => res.json( data ) )
+    .catch( next );
 });
 
 export default router;


### PR DESCRIPTION
Introduces three key pieces:

1. Wrapper for NCBI EUTILS
  - Basically copy-paste from Factoid

2. Index proteins for a given taxon in `datasource.js/ncbi`
  - Add SARS-CoV-2 genes from file using existing code
  - Introduce protein-level records for SARS-CoV-2 due due to multiple mature protein chains derived from genes
  - The complement of proteins is sourced from NCBI EUTILS, given an organisms ID

3. Indexing `processing.js`
  - Index the SARS-CoV-2 records all at once from 'source' i.e, not a file

Notes:
  - Overall grounding tests did not deviate much at all (~9% error rate) from before (analyzed about a year ago?)
  - For proteins, synonyms are generated based upon the title/label which have some particular formatting in NCBI
  - There's probably no consensus on synonyms or naming given how new this all is
  - Need to add env variable for `NCBI_EUTILS_API_KEY`
  

Refs #72, https://github.com/PathwayCommons/factoid/issues/699