### PR TITLE
Add attributes to identify the source database

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -32,16 +32,16 @@ export const INPUT_PATH = env('INPUT_PATH', 'input');
 
 export const UNIPROT_FILE_NAME = env('UNIPROT_FILE_NAME', 'uniprot.xml');
 export const UNIPROT_URL = env('UNIPROT_URL', 'ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.xml.gz');
-export const NS_UNIPROT_KNOWLEDGEBASE = env('NS_UNIPROT_KNOWLEDGEBASE', 'uniprot');
+export const ID_PREFIX_UNIPROT_KNOWLEDGEBASE = env('ID_PREFIX_UNIPROT_KNOWLEDGEBASE', 'uniprot');
 
 export const CHEBI_FILE_NAME = env('CHEBI_FILE_NAME', 'chebi.owl');
 export const CHEBI_URL = env('CHEBI_URL', 'ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.owl.gz');
-export const NS_CHEBI = env('NS_CHEBI', 'CHEBI');
+export const ID_PREFIX_CHEBI = env('ID_PREFIX_CHEBI', 'CHEBI');
 
 export const NCBI_FILE_NAME = env('NCBI_FILE_NAME', 'ncbi');
 export const NCBI_URL = env('NCBI_URL', 'ftp://ftp.ncbi.nih.gov/gene/DATA/gene_info.gz');
 export const NCBI_EUTILS_BASE_URL = env('NCBI_EUTILS_BASE_URL', 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/');
 export const NCBI_EUTILS_API_KEY = env('NCBI_EUTILS_API_KEY', 'b99e10ebe0f90d815a7a99f18403aab08008');
-export const NS_NCBI_GENE = env('NS_NCBI_GENE', 'ncbigene');
-export const NS_NCBI_PROTEIN = env('NS_NCBI_PROTEIN', 'ncbiprotein');
+export const ID_PREFIX_NCBI_GENE = env('ID_PREFIX_NCBI_GENE', 'ncbigene');
+export const ID_PREFIX_NCBI_PROTEIN = env('ID_PREFIX_NCBI_PROTEIN', 'ncbiprotein');
 

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -32,20 +32,20 @@ export const INPUT_PATH = env('INPUT_PATH', 'input');
 
 export const UNIPROT_FILE_NAME = env('UNIPROT_FILE_NAME', 'uniprot.xml');
 export const UNIPROT_URL = env('UNIPROT_URL', 'ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.xml.gz');
-export const ID_PREFIX_UNIPROT_KNOWLEDGEBASE = env('ID_PREFIX_UNIPROT_KNOWLEDGEBASE', 'uniprot');
+export const DB_PREFIX_UNIPROT_KNOWLEDGEBASE = env('DB_PREFIX_UNIPROT_KNOWLEDGEBASE', 'uniprot');
 export const DB_NAME_UNIPROT_KNOWLEDGEBASE = env('DB_NAME_UNIPROT_KNOWLEDGEBASE', 'UniProt Knowledgebase');
 
 export const CHEBI_FILE_NAME = env('CHEBI_FILE_NAME', 'chebi.owl');
 export const CHEBI_URL = env('CHEBI_URL', 'ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.owl.gz');
-export const ID_PREFIX_CHEBI = env('ID_PREFIX_CHEBI', 'CHEBI');
+export const DB_PREFIX_CHEBI = env('DB_PREFIX_CHEBI', 'CHEBI');
 export const DB_NAME_CHEBI = env('DB_NAME_CHEBI', 'ChEBI');
 
 export const NCBI_FILE_NAME = env('NCBI_FILE_NAME', 'ncbi');
 export const NCBI_URL = env('NCBI_URL', 'ftp://ftp.ncbi.nih.gov/gene/DATA/gene_info.gz');
 export const NCBI_EUTILS_BASE_URL = env('NCBI_EUTILS_BASE_URL', 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/');
 export const NCBI_EUTILS_API_KEY = env('NCBI_EUTILS_API_KEY', 'b99e10ebe0f90d815a7a99f18403aab08008');
-export const ID_PREFIX_NCBI_GENE = env('ID_PREFIX_NCBI_GENE', 'ncbigene');
+export const DB_PREFIX_NCBI_GENE = env('DB_PREFIX_NCBI_GENE', 'ncbigene');
 export const DB_NAME_NCBI_GENE  = env('DB_NAME_NCBI_GENE', 'NCBI Gene');
-export const ID_PREFIX_NCBI_PROTEIN = env('ID_PREFIX_NCBI_PROTEIN', 'ncbiprotein');
+export const DB_PREFIX_NCBI_PROTEIN = env('DB_PREFIX_NCBI_PROTEIN', 'ncbiprotein');
 export const DB_NAME_NCBI_PROTEIN = env('DB_NAME_NCBI_PROTEIN', 'NCBI Protein');
 

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -32,12 +32,16 @@ export const INPUT_PATH = env('INPUT_PATH', 'input');
 
 export const UNIPROT_FILE_NAME = env('UNIPROT_FILE_NAME', 'uniprot.xml');
 export const UNIPROT_URL = env('UNIPROT_URL', 'ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.xml.gz');
+export const NS_UNIPROT_KNOWLEDGEBASE = env('NS_UNIPROT_KNOWLEDGEBASE', 'uniprot');
 
 export const CHEBI_FILE_NAME = env('CHEBI_FILE_NAME', 'chebi.owl');
 export const CHEBI_URL = env('CHEBI_URL', 'ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.owl.gz');
+export const NS_CHEBI = env('NS_CHEBI', 'CHEBI');
 
 export const NCBI_FILE_NAME = env('NCBI_FILE_NAME', 'ncbi');
 export const NCBI_URL = env('NCBI_URL', 'ftp://ftp.ncbi.nih.gov/gene/DATA/gene_info.gz');
 export const NCBI_EUTILS_BASE_URL = env('NCBI_EUTILS_BASE_URL', 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/');
 export const NCBI_EUTILS_API_KEY = env('NCBI_EUTILS_API_KEY', 'b99e10ebe0f90d815a7a99f18403aab08008');
+export const NS_NCBI_GENE = env('NS_NCBI_GENE', 'ncbigene');
+export const NS_NCBI_PROTEIN = env('NS_NCBI_PROTEIN', 'ncbiprotein');
 

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -33,15 +33,19 @@ export const INPUT_PATH = env('INPUT_PATH', 'input');
 export const UNIPROT_FILE_NAME = env('UNIPROT_FILE_NAME', 'uniprot.xml');
 export const UNIPROT_URL = env('UNIPROT_URL', 'ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.xml.gz');
 export const ID_PREFIX_UNIPROT_KNOWLEDGEBASE = env('ID_PREFIX_UNIPROT_KNOWLEDGEBASE', 'uniprot');
+export const DB_NAME_UNIPROT_KNOWLEDGEBASE = env('DB_NAME_UNIPROT_KNOWLEDGEBASE', 'UniProt Knowledgebase');
 
 export const CHEBI_FILE_NAME = env('CHEBI_FILE_NAME', 'chebi.owl');
 export const CHEBI_URL = env('CHEBI_URL', 'ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.owl.gz');
 export const ID_PREFIX_CHEBI = env('ID_PREFIX_CHEBI', 'CHEBI');
+export const DB_NAME_CHEBI = env('DB_NAME_CHEBI', 'ChEBI');
 
 export const NCBI_FILE_NAME = env('NCBI_FILE_NAME', 'ncbi');
 export const NCBI_URL = env('NCBI_URL', 'ftp://ftp.ncbi.nih.gov/gene/DATA/gene_info.gz');
 export const NCBI_EUTILS_BASE_URL = env('NCBI_EUTILS_BASE_URL', 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/');
 export const NCBI_EUTILS_API_KEY = env('NCBI_EUTILS_API_KEY', 'b99e10ebe0f90d815a7a99f18403aab08008');
 export const ID_PREFIX_NCBI_GENE = env('ID_PREFIX_NCBI_GENE', 'ncbigene');
+export const DB_NAME_NCBI_GENE  = env('DB_NAME_NCBI_GENE', 'NCBI Gene');
 export const ID_PREFIX_NCBI_PROTEIN = env('ID_PREFIX_NCBI_PROTEIN', 'ncbiprotein');
+export const DB_NAME_NCBI_PROTEIN = env('DB_NAME_NCBI_PROTEIN', 'NCBI Protein');
 

--- a/src/server/datasource/chebi.js
+++ b/src/server/datasource/chebi.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, CHEBI_FILE_NAME, CHEBI_URL } from '../config';
+import { INPUT_PATH, CHEBI_FILE_NAME, CHEBI_URL, NS_CHEBI } from '../config';
 import { db } from '../db';
 import XmlParser from '../parser/xml-parser';
 
@@ -62,6 +62,7 @@ const processEntry = entry => {
   let namespace = ENTRY_NS;
   let type = ENTRY_TYPE;
 
+  const id_prefix = NS_CHEBI;
   let id = findChild( entry, XML_TAGS.ID ).replace('CHEBI:', '');
   let name = findChild( entry, XML_TAGS.NAME );
   let inchi = findChild( entry, XML_TAGS.INCHI );
@@ -76,7 +77,7 @@ const processEntry = entry => {
   let formulae = filterChildren( entry, XML_TAGS.FORMULA );
   let summary = findChild( entry, XML_TAGS.SUMMARY );
 
-  return { namespace, type, id, name, inchi, inchiKey, synonyms,
+  return { namespace, type, id_prefix, id, name, inchi, inchiKey, synonyms,
     charge, mass, monoisotopicMass, formulae, summary };
 };
 

--- a/src/server/datasource/chebi.js
+++ b/src/server/datasource/chebi.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, CHEBI_FILE_NAME, CHEBI_URL, ID_PREFIX_CHEBI, DB_NAME_CHEBI } from '../config';
+import { INPUT_PATH, CHEBI_FILE_NAME, CHEBI_URL, DB_PREFIX_CHEBI, DB_NAME_CHEBI } from '../config';
 import { db } from '../db';
 import XmlParser from '../parser/xml-parser';
 
@@ -62,8 +62,8 @@ const processEntry = entry => {
   let namespace = ENTRY_NS;
   let type = ENTRY_TYPE;
 
-  const db_name = DB_NAME_CHEBI;
-  const id_prefix = ID_PREFIX_CHEBI;
+  const dbName = DB_NAME_CHEBI;
+  const dbPrefix = DB_PREFIX_CHEBI;
   let id = findChild( entry, XML_TAGS.ID ).replace('CHEBI:', '');
   let name = findChild( entry, XML_TAGS.NAME );
   let inchi = findChild( entry, XML_TAGS.INCHI );
@@ -78,7 +78,7 @@ const processEntry = entry => {
   let formulae = filterChildren( entry, XML_TAGS.FORMULA );
   let summary = findChild( entry, XML_TAGS.SUMMARY );
 
-  return { namespace, type, db_name, id_prefix, id, name, inchi, inchiKey, synonyms,
+  return { namespace, type, dbName, dbPrefix, id, name, inchi, inchiKey, synonyms,
     charge, mass, monoisotopicMass, formulae, summary };
 };
 

--- a/src/server/datasource/chebi.js
+++ b/src/server/datasource/chebi.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, CHEBI_FILE_NAME, CHEBI_URL, NS_CHEBI } from '../config';
+import { INPUT_PATH, CHEBI_FILE_NAME, CHEBI_URL, ID_PREFIX_CHEBI } from '../config';
 import { db } from '../db';
 import XmlParser from '../parser/xml-parser';
 
@@ -62,7 +62,7 @@ const processEntry = entry => {
   let namespace = ENTRY_NS;
   let type = ENTRY_TYPE;
 
-  const id_prefix = NS_CHEBI;
+  const id_prefix = ID_PREFIX_CHEBI;
   let id = findChild( entry, XML_TAGS.ID ).replace('CHEBI:', '');
   let name = findChild( entry, XML_TAGS.NAME );
   let inchi = findChild( entry, XML_TAGS.INCHI );

--- a/src/server/datasource/chebi.js
+++ b/src/server/datasource/chebi.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, CHEBI_FILE_NAME, CHEBI_URL, ID_PREFIX_CHEBI } from '../config';
+import { INPUT_PATH, CHEBI_FILE_NAME, CHEBI_URL, ID_PREFIX_CHEBI, DB_NAME_CHEBI } from '../config';
 import { db } from '../db';
 import XmlParser from '../parser/xml-parser';
 
@@ -62,6 +62,7 @@ const processEntry = entry => {
   let namespace = ENTRY_NS;
   let type = ENTRY_TYPE;
 
+  const db_name = DB_NAME_CHEBI;
   const id_prefix = ID_PREFIX_CHEBI;
   let id = findChild( entry, XML_TAGS.ID ).replace('CHEBI:', '');
   let name = findChild( entry, XML_TAGS.NAME );
@@ -77,7 +78,7 @@ const processEntry = entry => {
   let formulae = filterChildren( entry, XML_TAGS.FORMULA );
   let summary = findChild( entry, XML_TAGS.SUMMARY );
 
-  return { namespace, type, id_prefix, id, name, inchi, inchiKey, synonyms,
+  return { namespace, type, db_name, id_prefix, id, name, inchi, inchiKey, synonyms,
     charge, mass, monoisotopicMass, formulae, summary };
 };
 

--- a/src/server/datasource/ncbi.js
+++ b/src/server/datasource/ncbi.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, NCBI_FILE_NAME, NCBI_URL, ID_PREFIX_NCBI_PROTEIN, ID_PREFIX_NCBI_GENE, DB_NAME_NCBI_GENE, DB_NAME_NCBI_PROTEIN } from '../config';
+import { INPUT_PATH, NCBI_FILE_NAME, NCBI_URL, DB_PREFIX_NCBI_PROTEIN, DB_PREFIX_NCBI_GENE, DB_NAME_NCBI_GENE, DB_NAME_NCBI_PROTEIN } from '../config';
 import { db } from '../db';
 import { seqPromise } from '../util';
 import DelimitedParser from '../parser/delimited-parser';
@@ -57,8 +57,8 @@ const processEntry = entryLine => {
 
   let organism = nodes[ NODE_INDICES.ORGANISM ];
   let organismName = getOrganismById(organism).name;
-  const db_name = DB_NAME_NCBI_GENE;
-  const id_prefix = ID_PREFIX_NCBI_GENE;
+  const dbName = DB_NAME_NCBI_GENE;
+  const dbPrefix = DB_PREFIX_NCBI_GENE;
   let id = nodes[ NODE_INDICES.ID ];
   let name = nodes[ NODE_INDICES.SYMBOL ];
 
@@ -79,7 +79,7 @@ const processEntry = entryLine => {
   [ NODE_INDICES.DESCRIPTION, NODE_INDICES.NA_SYMBOL, NODE_INDICES.NA_FULL_NAME ]
     .forEach( i => pushIfValid( synonyms, nodes[ i ] ) );
 
-  return { namespace, type, db_name, id_prefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
+  return { namespace, type, dbName, dbPrefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
 };
 
 const includeEntry = entryLine => {
@@ -120,8 +120,8 @@ const updateOrganismProteins = tax_id => {
   const processEntry = entry => {
     const namespace = ENTRY_NS;
     const type = 'protein';
-    const db_name = DB_NAME_NCBI_PROTEIN;
-    const id_prefix = ID_PREFIX_NCBI_PROTEIN;
+    const dbName = DB_NAME_NCBI_PROTEIN;
+    const dbPrefix = DB_PREFIX_NCBI_PROTEIN;
     const id = _.get( entry, 'uid' );
     const organism = _.get( entry, 'taxid' );
     const organismName = getOrganismById( organism ).name;
@@ -129,7 +129,7 @@ const updateOrganismProteins = tax_id => {
     const synonyms = getSynonyms( entry );
     const dbXrefs = [];
     const typeOfGene = 'protein-coding';
-    return { namespace, type, db_name, id_prefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
+    return { namespace, type, dbName, dbPrefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
   };
 
   const parse = eSummaryResponse => {

--- a/src/server/datasource/ncbi.js
+++ b/src/server/datasource/ncbi.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, NCBI_FILE_NAME, NCBI_URL } from '../config';
+import { INPUT_PATH, NCBI_FILE_NAME, NCBI_URL, NS_NCBI_PROTEIN, NS_NCBI_GENE } from '../config';
 import { db } from '../db';
 import { seqPromise } from '../util';
 import DelimitedParser from '../parser/delimited-parser';
@@ -57,6 +57,7 @@ const processEntry = entryLine => {
 
   let organism = nodes[ NODE_INDICES.ORGANISM ];
   let organismName = getOrganismById(organism).name;
+  const id_prefix = NS_NCBI_GENE;
   let id = nodes[ NODE_INDICES.ID ];
   let name = nodes[ NODE_INDICES.SYMBOL ];
 
@@ -77,7 +78,7 @@ const processEntry = entryLine => {
   [ NODE_INDICES.DESCRIPTION, NODE_INDICES.NA_SYMBOL, NODE_INDICES.NA_FULL_NAME ]
     .forEach( i => pushIfValid( synonyms, nodes[ i ] ) );
 
-  return { namespace, type, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
+  return { namespace, type, id_prefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
 };
 
 const includeEntry = entryLine => {
@@ -118,6 +119,7 @@ const updateOrganismProteins = tax_id => {
   const processEntry = entry => {
     const namespace = ENTRY_NS;
     const type = 'protein';
+    const id_prefix = NS_NCBI_PROTEIN;
     const id = _.get( entry, 'uid' );
     const organism = _.get( entry, 'taxid' );
     const organismName = getOrganismById( organism ).name;
@@ -125,7 +127,7 @@ const updateOrganismProteins = tax_id => {
     const synonyms = getSynonyms( entry );
     const dbXrefs = [];
     const typeOfGene = 'protein-coding';
-    return { namespace, type, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
+    return { namespace, type, id_prefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
   };
 
   const parse = eSummaryResponse => {

--- a/src/server/datasource/ncbi.js
+++ b/src/server/datasource/ncbi.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, NCBI_FILE_NAME, NCBI_URL, ID_PREFIX_NCBI_PROTEIN, ID_PREFIX_NCBI_GENE } from '../config';
+import { INPUT_PATH, NCBI_FILE_NAME, NCBI_URL, ID_PREFIX_NCBI_PROTEIN, ID_PREFIX_NCBI_GENE, DB_NAME_NCBI_GENE, DB_NAME_NCBI_PROTEIN } from '../config';
 import { db } from '../db';
 import { seqPromise } from '../util';
 import DelimitedParser from '../parser/delimited-parser';
@@ -57,6 +57,7 @@ const processEntry = entryLine => {
 
   let organism = nodes[ NODE_INDICES.ORGANISM ];
   let organismName = getOrganismById(organism).name;
+  const db_name = DB_NAME_NCBI_GENE;
   const id_prefix = ID_PREFIX_NCBI_GENE;
   let id = nodes[ NODE_INDICES.ID ];
   let name = nodes[ NODE_INDICES.SYMBOL ];
@@ -78,7 +79,7 @@ const processEntry = entryLine => {
   [ NODE_INDICES.DESCRIPTION, NODE_INDICES.NA_SYMBOL, NODE_INDICES.NA_FULL_NAME ]
     .forEach( i => pushIfValid( synonyms, nodes[ i ] ) );
 
-  return { namespace, type, id_prefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
+  return { namespace, type, db_name, id_prefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
 };
 
 const includeEntry = entryLine => {
@@ -119,6 +120,7 @@ const updateOrganismProteins = tax_id => {
   const processEntry = entry => {
     const namespace = ENTRY_NS;
     const type = 'protein';
+    const db_name = DB_NAME_NCBI_PROTEIN;
     const id_prefix = ID_PREFIX_NCBI_PROTEIN;
     const id = _.get( entry, 'uid' );
     const organism = _.get( entry, 'taxid' );
@@ -127,7 +129,7 @@ const updateOrganismProteins = tax_id => {
     const synonyms = getSynonyms( entry );
     const dbXrefs = [];
     const typeOfGene = 'protein-coding';
-    return { namespace, type, id_prefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
+    return { namespace, type, db_name, id_prefix, id, organism, organismName, name, synonyms, dbXrefs, typeOfGene };
   };
 
   const parse = eSummaryResponse => {

--- a/src/server/datasource/ncbi.js
+++ b/src/server/datasource/ncbi.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, NCBI_FILE_NAME, NCBI_URL, NS_NCBI_PROTEIN, NS_NCBI_GENE } from '../config';
+import { INPUT_PATH, NCBI_FILE_NAME, NCBI_URL, ID_PREFIX_NCBI_PROTEIN, ID_PREFIX_NCBI_GENE } from '../config';
 import { db } from '../db';
 import { seqPromise } from '../util';
 import DelimitedParser from '../parser/delimited-parser';
@@ -57,7 +57,7 @@ const processEntry = entryLine => {
 
   let organism = nodes[ NODE_INDICES.ORGANISM ];
   let organismName = getOrganismById(organism).name;
-  const id_prefix = NS_NCBI_GENE;
+  const id_prefix = ID_PREFIX_NCBI_GENE;
   let id = nodes[ NODE_INDICES.ID ];
   let name = nodes[ NODE_INDICES.SYMBOL ];
 
@@ -119,7 +119,7 @@ const updateOrganismProteins = tax_id => {
   const processEntry = entry => {
     const namespace = ENTRY_NS;
     const type = 'protein';
-    const id_prefix = NS_NCBI_PROTEIN;
+    const id_prefix = ID_PREFIX_NCBI_PROTEIN;
     const id = _.get( entry, 'uid' );
     const organism = _.get( entry, 'taxid' );
     const organismName = getOrganismById( organism ).name;

--- a/src/server/datasource/uniprot.js
+++ b/src/server/datasource/uniprot.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, UNIPROT_FILE_NAME, UNIPROT_URL, ID_PREFIX_UNIPROT_KNOWLEDGEBASE } from '../config';
+import { INPUT_PATH, UNIPROT_FILE_NAME, UNIPROT_URL, ID_PREFIX_UNIPROT_KNOWLEDGEBASE, DB_NAME_UNIPROT_KNOWLEDGEBASE } from '../config';
 import { db } from '../db';
 import XmlParser from '../parser/xml-parser';
 import downloadFile from './download';
@@ -45,6 +45,7 @@ const getText = n => n && n.text;
 const processEntry = entry => {
   let namespace = ENTRY_NS;
   let type = ENTRY_TYPE;
+  const db_name = DB_NAME_UNIPROT_KNOWLEDGEBASE;
   const id_prefix = ID_PREFIX_UNIPROT_KNOWLEDGEBASE;
   let id = getText( _.find( entry.children, [ 'name', 'accession' ] ) );
   let name = getText( _.find( entry.children, [ 'name', 'name' ] ) );
@@ -69,7 +70,7 @@ const processEntry = entry => {
   // since uniprot uses weird names, use the first "protein name" instead, if possible
   name = proteinNames[0] || name;
 
-  return { namespace, type, id_prefix, id, organism, name, geneNames, proteinNames, synonyms };
+  return { namespace, type, db_name, id_prefix, id, organism, name, geneNames, proteinNames, synonyms };
 };
 
 const includeEntry = entry => {

--- a/src/server/datasource/uniprot.js
+++ b/src/server/datasource/uniprot.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, UNIPROT_FILE_NAME, UNIPROT_URL } from '../config';
+import { INPUT_PATH, UNIPROT_FILE_NAME, UNIPROT_URL, NS_UNIPROT_KNOWLEDGEBASE } from '../config';
 import { db } from '../db';
 import XmlParser from '../parser/xml-parser';
 import downloadFile from './download';
@@ -45,6 +45,7 @@ const getText = n => n && n.text;
 const processEntry = entry => {
   let namespace = ENTRY_NS;
   let type = ENTRY_TYPE;
+  const id_prefix = NS_UNIPROT_KNOWLEDGEBASE;
   let id = getText( _.find( entry.children, [ 'name', 'accession' ] ) );
   let name = getText( _.find( entry.children, [ 'name', 'name' ] ) );
   let organism = getOrganism( entry );
@@ -68,7 +69,7 @@ const processEntry = entry => {
   // since uniprot uses weird names, use the first "protein name" instead, if possible
   name = proteinNames[0] || name;
 
-  return { namespace, type, id, organism, name, geneNames, proteinNames, synonyms };
+  return { namespace, type, id_prefix, id, organism, name, geneNames, proteinNames, synonyms };
 };
 
 const includeEntry = entry => {

--- a/src/server/datasource/uniprot.js
+++ b/src/server/datasource/uniprot.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, UNIPROT_FILE_NAME, UNIPROT_URL, NS_UNIPROT_KNOWLEDGEBASE } from '../config';
+import { INPUT_PATH, UNIPROT_FILE_NAME, UNIPROT_URL, ID_PREFIX_UNIPROT_KNOWLEDGEBASE } from '../config';
 import { db } from '../db';
 import XmlParser from '../parser/xml-parser';
 import downloadFile from './download';
@@ -45,7 +45,7 @@ const getText = n => n && n.text;
 const processEntry = entry => {
   let namespace = ENTRY_NS;
   let type = ENTRY_TYPE;
-  const id_prefix = NS_UNIPROT_KNOWLEDGEBASE;
+  const id_prefix = ID_PREFIX_UNIPROT_KNOWLEDGEBASE;
   let id = getText( _.find( entry.children, [ 'name', 'accession' ] ) );
   let name = getText( _.find( entry.children, [ 'name', 'name' ] ) );
   let organism = getOrganism( entry );

--- a/src/server/datasource/uniprot.js
+++ b/src/server/datasource/uniprot.js
@@ -3,7 +3,7 @@
 import path from 'path';
 import _ from 'lodash';
 
-import { INPUT_PATH, UNIPROT_FILE_NAME, UNIPROT_URL, ID_PREFIX_UNIPROT_KNOWLEDGEBASE, DB_NAME_UNIPROT_KNOWLEDGEBASE } from '../config';
+import { INPUT_PATH, UNIPROT_FILE_NAME, UNIPROT_URL, DB_PREFIX_UNIPROT_KNOWLEDGEBASE, DB_NAME_UNIPROT_KNOWLEDGEBASE } from '../config';
 import { db } from '../db';
 import XmlParser from '../parser/xml-parser';
 import downloadFile from './download';
@@ -45,8 +45,8 @@ const getText = n => n && n.text;
 const processEntry = entry => {
   let namespace = ENTRY_NS;
   let type = ENTRY_TYPE;
-  const db_name = DB_NAME_UNIPROT_KNOWLEDGEBASE;
-  const id_prefix = ID_PREFIX_UNIPROT_KNOWLEDGEBASE;
+  const dbName = DB_NAME_UNIPROT_KNOWLEDGEBASE;
+  const dbPrefix = DB_PREFIX_UNIPROT_KNOWLEDGEBASE;
   let id = getText( _.find( entry.children, [ 'name', 'accession' ] ) );
   let name = getText( _.find( entry.children, [ 'name', 'name' ] ) );
   let organism = getOrganism( entry );
@@ -70,7 +70,7 @@ const processEntry = entry => {
   // since uniprot uses weird names, use the first "protein name" instead, if possible
   name = proteinNames[0] || name;
 
-  return { namespace, type, db_name, id_prefix, id, organism, name, geneNames, proteinNames, synonyms };
+  return { namespace, type, dbName, dbPrefix, id, organism, name, geneNames, proteinNames, synonyms };
 };
 
 const includeEntry = entry => {


### PR DESCRIPTION
Add two attributes: 
1. `dbPrefix`
  - This contains the namespace for the database
  - Use it like `https://identifiers.org/<dbPrefix>:<id>`
2. `dbName`
  - This is the name (e.g. UniProt Knowledgebase). Useful for link display and used in BioPAX Xrefs

Refs #75 
