### PR TITLE
Server dependent on successful data refresh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ FROM node:10.15.3
 # Allow user configuration of variable at build-time using --build-arg flag
 ARG NODE_ENV
 
-# Initialize env variables and override with build-time flag, if set 
+# Initialize env variables and override with build-time flag, if set
 ENV NODE_ENV ${NODE_ENV:-production}
 
 # Create an unprivileged user w/ home directory
 RUN groupadd appuser \
   && useradd --gid appuser --shell /bin/bash --create-home appuser
-  
+
 # Create app directory
 RUN mkdir -p /home/appuser/app
 WORKDIR /home/appuser/app
@@ -29,5 +29,5 @@ EXPOSE 3000
 RUN chown appuser:appuser -R /home/appuser/app
 USER appuser
 
-# Run the command that starts the app
-CMD npm start
+# Run the command that indexes data and starts the app
+CMD npm run boot

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "clear:uniprot": "node -r esm src/server/datasource/cli clear uniprot",
     "clear:chebi": "node -r esm src/server/datasource/cli clear chebi",
     "clear:ncbi": "node -r esm src/server/datasource/cli clear ncbi",
-    "ci": "run-s lint"
+    "ci": "run-s lint",
+    "boot": "run-s refresh start"
   },
   "dependencies": {
     "benchmark": "^2.1.4",

--- a/src/server/datasource/cli.js
+++ b/src/server/datasource/cli.js
@@ -34,8 +34,10 @@ if( op === 'clear' && passedSourceId === 'all' ){
     const duration = formatDistanceStrict(endTime, startTime);
 
     logger.info(`Successfully applied ${op} on source '${passedSourceId}' in ${duration}`);
+    process.exit(0);
   }).catch(err => {
     logger.error(`Failed to apply ${op} on source '${passedSourceId}'`);
     logger.error(err);
+    process.exit(1);
   });
 }

--- a/src/server/datasource/download.js
+++ b/src/server/datasource/download.js
@@ -22,6 +22,7 @@ const ftpDownload = (url, outFileName) => {
         client.on('ready', () => {
           client.get(parsedUrl.pathname, function(err, fileStream){
             if( err ){
+              client.destroy();
               reject(err);
             } else {
               resolve(fileStream);


### PR DESCRIPTION
New npm script 'boot' that ties the success of a data 'refresh' (clear; update) to server 'start'. Docker default command is 'npm run boot' instead of 'npm start'.

Compensatory changes:
  - Factoid docker-compose will be simplified, merging the 'grounding' and 'indexer' services into one (https://github.com/PathwayCommons/factoid/pull/802)
  - ci server need updates to use 'boot' (TODO)
  
Refs #76 