### PR TITLE
Index UniProt and its associated dbXrefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "benchmark:uniprot": "node -r esm benchmark/uniprot",
     "benchmark:chebi": "node -r esm benchmark/chebi",
     "benchmark:ncbi": "node -r esm benchmark/ncbi",
-    "update": "run-s update:chebi update:ncbi",
+    "update": "run-s update:uniprot update:chebi update:ncbi",
     "refresh": "run-s clear update",
     "update:uniprot": "node -r esm src/server/datasource/cli update uniprot",
     "update:chebi": "node -r esm src/server/datasource/cli update chebi",

--- a/src/server/datasource/chebi.js
+++ b/src/server/datasource/chebi.js
@@ -88,7 +88,7 @@ const includeEntry = entry => {
 
 const parseXml = (filePath, onData, onEnd) => {
   let rootTag = XML_TAGS.CLASS;
-  let omitList = [ XML_TAGS.RDF, XML_TAGS.ONTOLOGY, XML_TAGS.ANNOTATION_PROPERTY,
+  let omitList = [ XML_TAGS.ONTOLOGY, XML_TAGS.ANNOTATION_PROPERTY,
     XML_TAGS.OBJECT_PROPERTY, XML_TAGS.AXIOM ];
 
   XmlParser( filePath, rootTag, omitList, { onEnd, onData } );

--- a/src/server/datasource/uniprot.js
+++ b/src/server/datasource/uniprot.js
@@ -42,6 +42,8 @@ const getAttributes = n => n && n.attributes;
 
 const getText = n => n && n.text;
 
+const getDbXref = ({ attributes: { type: db, id } }) => ({ db, id }); //required
+
 const processEntry = entry => {
   let namespace = ENTRY_NS;
   let type = ENTRY_TYPE;
@@ -58,6 +60,7 @@ const processEntry = entry => {
   let recShortProteinName = getShortName( recProtName );
   let altProteinNames = protein && _.filter( protein.children, ['name', 'alternativeName'] ).map( getShortOrFullName );
   let subProteinNames = protein && _.filter( protein.children, ['name', 'submittedName'] ).map( getShortOrFullName );
+  let dbXrefs = _.filter( entry.children, ['name', 'dbReference'] ).map( getDbXref );
 
   let proteinNames = [];
   pushIfNonNil( proteinNames, recShortProteinName );
@@ -70,7 +73,7 @@ const processEntry = entry => {
   // since uniprot uses weird names, use the first "protein name" instead, if possible
   name = proteinNames[0] || name;
 
-  return { namespace, type, dbName, dbPrefix, id, organism, name, geneNames, proteinNames, synonyms };
+  return { namespace, type, dbName, dbPrefix, id, organism, name, geneNames, proteinNames, synonyms, dbXrefs };
 };
 
 const includeEntry = entry => {
@@ -81,7 +84,7 @@ const includeEntry = entry => {
 
 const parseXml = (filePath, onData, onEnd) => {
   let rootTag = 'entry';
-  let omitList = ['uniprot' ,'lineage', 'reference', 'evidence'];
+  let omitList = ['lineage', 'reference', 'evidence', 'copyright', 'comment'];
 
   XmlParser( filePath, rootTag, omitList, { onEnd, onData } );
 };


### PR DESCRIPTION
- `update` npm script now includes uniprot
-  UniProt now includes dbXrefs, in particular from NCBI Gene (aka `GeneID`)
- XML parsing
  - This was not properly ignoring the tags in `omitList`, in particular, skipping children etc so had to update this in order to even access the dbXrefs in UniProt. 

Refs #88 and #89 