### PR TITLE
db: 'map' between selected database identifiers 

### DIFF
--- a/src/server/datasource/aggregate.js
+++ b/src/server/datasource/aggregate.js
@@ -117,12 +117,11 @@ const get = function(namespace, id){
 };
 
 /**
- * Map entities to a target namespace (dbto) from a given namespace and id.
- * @param {string} dbto dbPrefix of database to find records in
- * @param {string} dbfrom dbPrefix of database the provided id
- * @param {string} id The id of entity in the dbfrom database
- * @returns {Promise} Promise objects represents the entity with the given id from the given namespace,
- * if there is no such entity it represents null.
+ * Retrieve dbXrefs in another database, given a db and one or more ids
+ * @param {string} dbto MIRIAM prefix of target database
+ * @param {string} dbfrom MIRIAM prefix of source database
+ * @param {string | Object} id The identifier or list of identifiers in dbfrom
+ * @returns {Promise} Promise objects containing dbXrefs for each element of id
  */
 const map = function( dbfrom, id, dbto ){
   return db.map( dbfrom, id, dbto );

--- a/src/server/datasource/aggregate.js
+++ b/src/server/datasource/aggregate.js
@@ -54,7 +54,7 @@ const search = function(searchString, namespace = ['ncbi', 'chebi'], organismOrd
       const getSynonym = ent => ent.synonyms.length === 1 ? sanitize(ent.synonyms[0]) : null;
       const s1 = getSynonym(ent1) || '--nosynonym1';
       const s2 = getSynonym(ent2) || '--nosynonym2';
-      
+
       return isRootStrainOrgId(org1.id) && org1.id === org2.id && (n1 === n2 || s1 === s2 || n1 === s2 || s1 === n2);
     });
   };
@@ -63,13 +63,13 @@ const search = function(searchString, namespace = ['ncbi', 'chebi'], organismOrd
     let task = Future.wrap(function(args, next){ // code in this block runs in its own thread
       let res = filterStrains(args.ents);
       let err = null;
-  
+
       next( err, res );
     });
-  
+
     return task({ ents }).promise();
   };
-  
+
   const doSearches = () => {
     const join = ress => _.uniqWith(_.concat(...ress), (ent1, ent2) => {
       return ent1.namespace === ent2.namespace && ent1.id === ent2.id;
@@ -79,10 +79,10 @@ const search = function(searchString, namespace = ['ncbi', 'chebi'], organismOrd
       let task = Future.wrap(function(args, next){ // code in this block runs in its own thread
         let res = join(args.ress);
         let err = null;
-    
+
         next( err, res );
       });
-    
+
       return task({ ress }).promise();
     };
 
@@ -116,4 +116,16 @@ const get = function(namespace, id){
   return db.get(id, namespace);
 };
 
-export const aggregate = { search, get };
+/**
+ * Map entities to a target namespace (dbto) from a given namespace and id.
+ * @param {string} dbto dbPrefix of database to find records in
+ * @param {string} dbfrom dbPrefix of database the provided id
+ * @param {string} id The id of entity in the dbfrom database
+ * @returns {Promise} Promise objects represents the entity with the given id from the given namespace,
+ * if there is no such entity it represents null.
+ */
+const map = function( dbfrom, id, dbto ){
+  return db.map( dbfrom, id, dbto );
+};
+
+export const aggregate = { search, get, map };

--- a/src/server/db/db.js
+++ b/src/server/db/db.js
@@ -423,7 +423,7 @@ const db = {
       ];
 
       if( dbfrom === MAPPING_NAMESPACE ){
-        // Starting from MAPPING_NAMESPACE, so just filter on the id and dbXrefs with dbtoName
+        // 'get' conditional on dbXrefs having the dbtoName
         let byId = {
           term: {
             id
@@ -444,7 +444,8 @@ const db = {
         filter.push( byId, byDbto );
 
       } else {
-        // Filter on co-occurrence of dbXrefs with dbtoName and (dbfromName, id)
+        // Filter dbXrefs for dbfrom + id
+        // Filter dbXrefs for dbto unless it is in the MAPPING_NAMESPACE
         let byDbfrom = {
           nested: {
             path: 'dbXrefs',
@@ -518,7 +519,7 @@ const db = {
       });
     };
 
-    const body = _.flatten( _.concat( [], id ).map( queryFactory ) );
+    const body = _.flatten( id.map( queryFactory ) );
     const searchQuery = _.defaults( { body }, MSEARCH_DEFAULTS );
 
     return client.msearch( searchQuery )

--- a/src/server/db/db.js
+++ b/src/server/db/db.js
@@ -81,6 +81,17 @@ const db = {
           synonyms: {
             type: 'keyword',
             normalizer: 'name_norm'
+          },
+          dbXrefs: {
+            type: 'nested',
+            properties: {
+              db: {
+                type: 'keyword'
+              },
+              id: {
+                type: 'keyword'
+              }
+            }
           }
         }
       }
@@ -213,7 +224,7 @@ const db = {
 
       patches.forEach(patch => {
         const { namespace, id, addSynonyms } = patch;
-        
+
         if( namespace === entry.namespace && id === entry.id ){
           if( addSynonyms ){
             entry.synonyms.push(...addSynonyms);
@@ -363,6 +374,155 @@ const db = {
       index: INDEX,
       type: TYPE
     }).then( res => res.hits.hits.map( e => e._source )[0] );
+  },
+  /**
+   * Retrieve dbXrefs in another database, given a db and one or more ids
+   * @param {string} dbto MIRIAM prefix of target database
+   * @param {string} dbfrom MIRIAM prefix of source database
+   * @param {string | Object} id The identifier or list of identifiers in dbfrom
+   * @returns {Promise} Promise objects containing dbXrefs for each element of id
+   */
+  map: function( dbfrom, id, dbto ){
+    const MAPPING_NAMESPACE = 'uniprot'; // make this more generic
+    const MSEARCH_DEFAULTS = { index: INDEX };
+    const MIRIAM_2_UNIPROT_NAMES = new Map([
+      ['ncbigene', 'GeneID'],
+      ['refseq', 'RefSeq'],
+      ['chembl.target', 'ChEMBL'],
+      ['ensembl', 'Ensembl'],
+      ['genecards', 'GeneCards'],
+      ['hgnc', 'HGNC'],
+      ['reactome', 'Reactome'],
+      ['go', 'GO'],
+      ['interpro', 'InterPro'],
+      ['pfam', 'Pfam'],
+      ['supfam', 'SUPFAM'],
+      ['uniprot', 'uniprot']
+    ]);
+
+    id = _.concat( [], id ); // Accept string, array
+    const dbfromName = MIRIAM_2_UNIPROT_NAMES.get( dbfrom );
+    const dbtoName = MIRIAM_2_UNIPROT_NAMES.get( dbto );
+
+    if( !dbfromName || !dbtoName ) throw new Error('Unrecognized database name');
+
+    let client = this.connect();
+    const dbXrefsByDbto = entry => _.filter( _.get( entry, 'dbXrefs', [] ), [ 'db', dbtoName ] ).map( ({ id }) => ({ db: dbto, id }) );
+    let getDbXrefs = entries => _.flatten( entries.map( dbXrefsByDbto ) );
+    const getParentDbXrefs = entity => ({ db: _.get( entity, 'dbPrefix' ), id: _.get( entity, 'id' ) });
+
+    const queryFactory = id => {
+      const header = {};
+      const body = {};
+      const filter = [
+        {
+          term: {
+            [NS_FIELD]: MAPPING_NAMESPACE
+          }
+        }
+      ];
+
+      if( dbfromName === MAPPING_NAMESPACE ){
+        let byId = {
+          term: {
+            id
+          }
+        };
+        let byDbto = {
+          nested: {
+            path: 'dbXrefs',
+            query: {
+              bool: {
+                filter: {
+                  term: { 'dbXrefs.db': dbtoName }
+                }
+              }
+            }
+          }
+        };
+        filter.push( byId, byDbto );
+
+      } else {
+
+
+        let byDbfrom = {
+          nested: {
+            path: 'dbXrefs',
+            query: {
+              bool: {
+                filter: [
+                  {
+                    term: { 'dbXrefs.db': dbfromName }
+                  },
+                  {
+                    term: { 'dbXrefs.id': id }
+                  }
+                ]
+              }
+            }
+          }
+        };
+        let byDbto = {
+          nested: {
+            path: 'dbXrefs',
+            query: {
+              bool: {
+                filter: [
+                  {
+                    term: { 'dbXrefs.db': dbtoName }
+                  }
+                ]
+              }
+            }
+          }
+        };
+
+        filter.push( byDbfrom );
+
+        if ( dbto === MAPPING_NAMESPACE ){
+          getDbXrefs = entities => entities.map( getParentDbXrefs );
+
+        } else {
+          filter.push( byDbto );
+        }
+      }
+
+      _.set( body, ['query', 'bool', 'filter'], filter );
+
+      return [ header, body ];
+    };
+
+    const checkResponses = ({ responses }) => {
+      responses.forEach( response => {
+        const hasError = _.has( response, 'error' );
+        const ok = _.get( response, 'status' ) == 200;
+        if( hasError || !ok ){
+          throw new Error( `Response Error: ${JSON.stringify( response )}` );
+        } else {
+          return;
+        }
+      });
+      return responses;
+    };
+
+    const processResponses = responses => {
+      return responses.map( ( response, index ) => {
+        const entries = response.hits.hits.map( hit => hit._source );
+        const dbXrefs = getDbXrefs( entries );
+        return {
+          dbfrom,
+          id: id[index],
+          dbXrefs
+        };
+      });
+    };
+
+    const body = _.flatten( _.concat( [], id ).map( queryFactory ) );
+    const searchQuery = _.defaults( { body }, MSEARCH_DEFAULTS );
+
+    return client.msearch( searchQuery )
+      .then( checkResponses )
+      .then( processResponses );
   },
   /**
    * Check if the elasticsearch index dedicated for the app exists.

--- a/src/server/db/db.js
+++ b/src/server/db/db.js
@@ -383,7 +383,7 @@ const db = {
    * @returns {Promise} Promise objects containing dbXrefs for each element of id
    */
   map: function( dbfrom, id, dbto ){
-    const MAPPING_NAMESPACE = 'uniprot'; // make this more generic
+    const MAPPING_NAMESPACE = 'uniprot';
     const MSEARCH_DEFAULTS = { index: INDEX };
     const MIRIAM_2_UNIPROT_NAMES = new Map([
       ['ncbigene', 'GeneID'],
@@ -415,14 +415,15 @@ const db = {
       const header = {};
       const body = {};
       const filter = [
-        {
+        { // Look in MAPPING_NAMESPACE
           term: {
             [NS_FIELD]: MAPPING_NAMESPACE
           }
         }
       ];
 
-      if( dbfromName === MAPPING_NAMESPACE ){
+      if( dbfrom === MAPPING_NAMESPACE ){
+        // Starting from MAPPING_NAMESPACE, so just filter on the id and dbXrefs with dbtoName
         let byId = {
           term: {
             id
@@ -443,8 +444,7 @@ const db = {
         filter.push( byId, byDbto );
 
       } else {
-
-
+        // Filter on co-occurrence of dbXrefs with dbtoName and (dbfromName, id)
         let byDbfrom = {
           nested: {
             path: 'dbXrefs',
@@ -462,6 +462,7 @@ const db = {
             }
           }
         };
+
         let byDbto = {
           nested: {
             path: 'dbXrefs',

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -49,4 +49,10 @@ router.post('/get', function(req, res){
   aggregate.get(namespace, id).then(searchRes => res.json(searchRes));
 });
 
+// TODO swagger docs
+router.post('/map', function(req, res){
+  const { dbfrom, id, dbto } = req.body;
+  aggregate.map( dbfrom, id, dbto  ).then( searchRes => res.json( searchRes ) );
+});
+
 export default router;

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -49,7 +49,6 @@ router.post('/get', function(req, res){
   aggregate.get(namespace, id).then(searchRes => res.json(searchRes));
 });
 
-// TODO swagger docs
 router.post('/map', function(req, res){
   const { dbfrom, id, dbto } = req.body;
   aggregate.map( dbfrom, id, dbto  ).then( searchRes => res.json( searchRes ) );


### PR DESCRIPTION
Provides for a new endpoint `/map` that takes one or more identifiers from a database and returns one or more identifiers from a desired database, if they exist. 

Basically this thing looks through the uniprot dbXrefs for the co-occurence of databases the user wishes to map between.  Supported databases include (MIRIAM prefix): ncbigene, refseq, chembl.target, ensembl, genecards, hgnc, reactome, go, interpro, pfam, supfam, uniprot. 

- input
  - `id`:  a string or array of strings that represents identifiers
  - `dbfrom`: MIRIAM prefix of database corresponding to the `id`(s)
  - `dbto`: desired database in which to identify ids
- output
  - Array, one object for each element of `id` 
    - `dbfrom`, `id` from input
    - `dbXrefs` 
      - `db`, `id`

Example use:

IN
```json
{
  "id": [
    "NP_001119584.1"
  ],
  "dbfrom": "refseq",
  "dbto": "ncbigene"
}
```

OUT
```json
[
  {
    "dbfrom": "refseq",
    "id": "NP_001119584.1",
    "dbXrefs": [
      {
        "db": "ncbigene",
        "id": "7157"
      }
    ]
  }
]
```

Refs: https://github.com/PathwayCommons/grounding-search/issues/97

