### PR TITLE
Sars-CoV support

### DIFF
--- a/src/server/datasource/eutils.js
+++ b/src/server/datasource/eutils.js
@@ -27,7 +27,7 @@ const EUTILS_ESUMMARY_URL = NCBI_EUTILS_BASE_URL + 'esummary.fcgi';
 const DEFAULT_ESUMMARY_PARAMS = {
   id: undefined,
   db: 'protein',
-  retstart: 1,
+  retstart: 0,
   retmode: 'json',
   retmax: 10000,
   query_key: undefined,

--- a/src/server/datasource/ncbi.js
+++ b/src/server/datasource/ncbi.js
@@ -21,6 +21,7 @@ const NODE_DELIMITER = '\t';
 const EMPTY_VALUE = '-';
 const DEFAULT_SCROLL = '10s';
 const TAX_ID_SARSCOV2 = '2697049';
+const TAX_ID_SARSCOV = '227984';
 
 const NODE_INDICES = Object.freeze({
   ORGANISM: 0,
@@ -127,7 +128,8 @@ const updateOrganismProteins = tax_id => {
   };
 
   const includeEntry = () => true;
-  const omittedUids = _.get( _.find( omissions, [ 'tax_id', TAX_ID_SARSCOV2 ] ), 'uids' );
+  const NCBI_omissions = omissions.filter( o => o.namespace == ENTRY_NS );
+  const omittedUids = _.flatten( NCBI_omissions.map( v => v.uids ) );
   const includeEntryWrtOmissions = entry => !_.includes( omittedUids, entry.uid );
 
   return eSearchSummaries( opts )
@@ -149,7 +151,8 @@ const download = function(){
 const index = function(){
   return Promise.all([
     updateFromFile(),
-    updateOrganismProteins( TAX_ID_SARSCOV2 )
+    updateOrganismProteins( TAX_ID_SARSCOV2 ),
+    updateOrganismProteins( TAX_ID_SARSCOV )
   ]);
 };
 

--- a/src/server/datasource/organisms.js
+++ b/src/server/datasource/organisms.js
@@ -43,6 +43,7 @@ class Organism {
  */
 const SORTED_MAIN_ORGANISMS = [
   new Organism(2697049, 'SARS-CoV-2'),
+  new Organism(227984, 'SARS-CoV'),
   new Organism(9606, 'Homo sapiens'),
   new Organism(10090, 'Mus musculus'),
   new Organism(ROOT_STRAINS.SCERVISIAE, 'Saccharomyces cervisiae', SCERVISIAE_STRAIN_IDS),

--- a/src/server/db/patches.js
+++ b/src/server/db/patches.js
@@ -293,6 +293,25 @@ const omissions = [
       '1796318604', //ORF8 protein
       '1798174256', //ORF10
     ]
+  },
+  {
+    tax_id: '227984',
+    uids: [
+      '1845982719', //S protein
+      '1845982722', //E protein
+      '1845982723', //M protein
+      '1845982729', //N protein
+      '1873624195', //ORF1ab protein
+      '1845982720', //ORF3a protein
+      '1845982721', //ORF3b protein
+      '1845982724', //ORF6  protein
+      '1845982725', //ORF7a protein
+      '1845982726', //ORF7b protein
+      '1845982727', //ORF8a protein
+      '1845982728', //ORF8b protein
+      '1845982731', //ORF9a protein
+      '1845982730', //ORF9b protein
+    ]
   }
 ];
 

--- a/src/server/db/patches.js
+++ b/src/server/db/patches.js
@@ -1,4 +1,6 @@
-const patches = [
+import _ from 'lodash';
+
+const PATCHES_TAXID_2697049 = [
   {
     namespace: 'ncbi',
     id: '43740568',
@@ -268,8 +270,182 @@ const patches = [
   }
 ];
 
+const PATCHES_TAXID_227984 = [
+  {
+    namespace: 'ncbi',
+    id: '1489668',
+    addSynonyms: [
+      'spike',
+      'spike protein',
+      'S glycoprotein'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '1489678',
+    addSynonyms: [
+      'ORF9a',
+      'ORF9a protein',
+      'nucleocapsid',
+      'nucleocapsid protein'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '1489680',
+    addSynonyms: [
+      'ORF1ab polyprotein',
+      'pp1ab',
+      'polyprotein pp1ab',
+      'replicase 1AB'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '1489671',
+    addSynonyms: [
+      'envelope protein',
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '1489669',
+    addSynonyms: [
+      'sars3a'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '1489679',
+    addSynonyms: [
+      'ORF9b'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '34555774',
+    addSynonyms: [
+      'NSP1',
+      'Non-structural protein 1',
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '34555775',
+    addSynonyms: [
+      'NSP2',
+      'Non-structural protein 2'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '34555776',
+    addSynonyms: [
+      'NSP3',
+      'Non-structural protein 3'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '34555778',
+    addSynonyms: [
+      'NSP4',
+      'Non-structural protein 4'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '29837498',
+    addSynonyms: [
+      'NSP5',
+      'Non-structural protein 5'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '29837499',
+    addSynonyms: [
+      'NSP6',
+      'Non-structural protein 6'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '29837500',
+    addSynonyms: [
+      'NSP7',
+      'Non-structural protein 7'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '29837501',
+    addSynonyms: [
+      'NSP8',
+      'Non-structural protein 8'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '29837502',
+    addSynonyms: [
+      'NSP9',
+      'Non-structural protein 9'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '29837503',
+    addSynonyms: [
+      'NSP10',
+      'Non-structural protein 10'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '1904811885',
+    addSynonyms: [
+      'NSP12',
+      'Non-structural protein 12'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '29837505',
+    addSynonyms: [
+      'NSP13',
+      'Non-structural protein 13'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '29837506',
+    addSynonyms: [
+      'NSP14',
+      'Non-structural protein 14'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '29837507',
+    addSynonyms: [
+      'NSP15',
+      'Non-structural protein 15'
+    ]
+  },
+  {
+    namespace: 'ncbi',
+    id: '30133975',
+    addSynonyms: [
+      'NSP16',
+      'Non-structural protein 16'
+    ]
+  }
+];
+
 const omissions = [
   {
+    namespace: 'ncbi',
     tax_id: '2697049',
     uids: [
       '1796318598', //S protein
@@ -295,6 +471,7 @@ const omissions = [
     ]
   },
   {
+    namespace: 'ncbi',
     tax_id: '227984',
     uids: [
       '1845982719', //S protein
@@ -314,5 +491,7 @@ const omissions = [
     ]
   }
 ];
+
+const patches = _.concat( [], PATCHES_TAXID_2697049, PATCHES_TAXID_227984 );
 
 export { patches, omissions };


### PR DESCRIPTION
- adds support for SARS-CoV in same manner as SARS-CoV-2 before it
- fixes an existing bug in ESUMARY opts, which otherwise skipped over first record 

Refs #101 