### PR TITLE
Fix bugs in testing data and test harness.

### DIFF
--- a/test/aggregate-quality.js
+++ b/test/aggregate-quality.js
@@ -12,7 +12,7 @@ const updateTestData = () => {
 };
 
 const searchEnt = ( name, organismOrdering ) => {
-  return aggregate.search( name, null, organismOrdering );
+  return aggregate.search( name, ['ncbi', 'chebi'], organismOrdering );
 };
 
 const getEnt = ( ns, id ) => aggregate.get( ns, id );
@@ -43,7 +43,7 @@ describe('Search and Get Aggregate', function(){
         if( !id || !namespace ) return;
         const expected = _.assign( {}, { namespace, id } );
         const organismOrdering = entity.organismOrdering || testCase.organismOrdering || [];
-        
+
         it(`search ${text} ${organismOrdering}`, function(){
           return ( searchEnt(text, organismOrdering)
             .then( results => {

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1753,7 +1753,7 @@
   },
   {
    "id": "http://dx.doi.org/10.1016/j.molcel.2016.12.021",
-   "organismOrdering": [9606, 10090, 11320, 11588, 11191],
+   "organismOrdering": [9606, 10090],
    "entities": [
     {
       "text": "RIG-I",


### PR DESCRIPTION
- Needed to accommodate the testing namespaces
- Bizarre species made their way into the `organismOrdering` in test data