### PR TITLE
Restore index data from published record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out.log
 /input/*
 !/input/datasource-inputs-go-here.txt
 .DS_Store
+.vscode

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -53,3 +53,4 @@ export const ESDUMP_LOCATION = env('ESDUMP_LOCATION', './input/');
 export const ZENODO_ACCESS_TOKEN = env('ZENODO_ACCESS_TOKEN', '');
 export const ZENODO_BASE_URL = env('ZENODO_BASE_URL', 'https://zenodo.org/');
 export const ZENODO_BUCKET_ID = env('ZENODO_BUCKET_ID', '');
+export const ZENODO_DEPOSITION_ID = env('ZENODO_DEPOSITION_ID', '');

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -53,4 +53,4 @@ export const ESDUMP_LOCATION = env('ESDUMP_LOCATION', './input/');
 export const ZENODO_ACCESS_TOKEN = env('ZENODO_ACCESS_TOKEN', '');
 export const ZENODO_BASE_URL = env('ZENODO_BASE_URL', 'https://zenodo.org/');
 export const ZENODO_BUCKET_ID = env('ZENODO_BUCKET_ID', '');
-export const ZENODO_DEPOSITION_ID = env('ZENODO_DEPOSITION_ID', '');
+export const ZENODO_DEPOSITION_ID = env('ZENODO_DEPOSITION_ID', '4495013');


### PR DESCRIPTION
- Restore the elasticsearch index by pulling from a publicly available, published versions of a Zenodo record containing the index files
- Dumping and pushing to  Zenodo is as before, requiring API token and deposition information 

Notes:
  - the production Zenodo data should first be published and this PR tested against it.

Refs #113