### PR TITLE
Up-to-date Swagger

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -54,3 +54,5 @@ export const ZENODO_ACCESS_TOKEN = env('ZENODO_ACCESS_TOKEN', '');
 export const ZENODO_BASE_URL = env('ZENODO_BASE_URL', 'https://zenodo.org/');
 export const ZENODO_BUCKET_ID = env('ZENODO_BUCKET_ID', '');
 export const ZENODO_DEPOSITION_ID = env('ZENODO_DEPOSITION_ID', '4495013');
+
+export const SWAGGER_HOST = env('SWAGGER_HOST', 'localhost:3000'); // e.g. grounding.baderlab.org

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -13,20 +13,37 @@ router.get('/', function(req, res) {
  * @swagger
  * /search:
  *   post:
- *     description: aggregate search service
+ *     description: Search for a grounding
  *     tags:
  *       - grounding-search
  *     produces:
  *       - application/json
  *     parameters:
- *       - name: q
- *         description: Search text
- *         in: formData
+ *       - name: body
+ *         description: Search parameters (JSON)
+ *         in: body
  *         required: true
- *         type: string
+ *         schema:
+ *           type: object
+ *           properties:
+ *             q:
+ *               type: string
+ *               description: The biological entity name to search for.
+ *               example: "p53"
+ *               required: true
+ *             organismOrdering:
+ *               type: array
+ *               description: An array of taxon IDs used to indicate tie-breaking ordering preferences (i.e. earlier entries in the array are ranked earlier in the resulting list in cases of tie-breaking).  By default, an ordering based on popularity is used.
+ *               example: ["9606", "10090"]
+ *               required: false
+ *             namespace:
+ *               type: array
+ *               description: An array of datasource namespaces to use as a filter (i.e. "ncbi", "chebi", or "uniprot").  By default, only NCBI and ChEBI are used.
+ *               example: ["ncbi", "chebi"]
+ *               required: false
  *     responses:
  *       200:
- *         description: Aggregate get query results
+ *         description: Search results (JSON array)
  */
 // e.g. POST /search { q: 'p53' }
 router.post('/search', function(req, res){
@@ -35,20 +52,86 @@ router.post('/search', function(req, res){
   aggregate.search(q, namespace, organismOrdering).then(ents => res.json(ents));
 });
 
-// TODO docs
+// for internal use / quick testing, e.g. http://localhost:3000/search?q=pcna
 router.get('/search', function(req, res){
   const { namespace, q, organismOrdering } = req.query;
 
-  aggregate.search(q, namespace, organismOrdering).then(ents => res.json(ents));
+  aggregate.search(q, namespace, organismOrdering.split(',')).then(ents => res.json(ents));
 });
 
-// TODO swagger docs
+/**
+ * @swagger
+ * /get:
+ *   post:
+ *     description: Get the metadata for a specified grounding
+ *     tags:
+ *       - grounding-search
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: body
+ *         description: Query parameters (JSON)
+ *         in: body
+ *         required: true
+ *         schema:
+ *           type: object
+ *           properties:
+ *             namespace:
+ *               type: string
+ *               description: The database namespace of the grounding (i.e. one of "ncbi", "chebi", or "uniprot").
+ *               example: "ncbi"
+ *               required: true
+ *             id:
+ *               type: string
+ *               description: The database identifier of the grounding.
+ *               example: "7157"
+ *               required: true
+ *     responses:
+ *       200:
+ *         description: The metadata for the grounding
+ */
 router.post('/get', function(req, res){
   const { namespace, id } = req.body;
 
   aggregate.get(namespace, id).then(searchRes => res.json(searchRes));
 });
 
+/**
+ * @swagger
+ * /map:
+ *   post:
+ *     description: Map a database identier from one namespace to another namespace (e.g. NCBI to Uniprot)
+ *     tags:
+ *       - grounding-search
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: body
+ *         description: Query parameters (JSON)
+ *         in: body
+ *         required: true
+ *         schema:
+ *           type: object
+ *           properties:
+ *             dbfrom:
+ *               type: string
+ *               description: The MIRIAM database prefix of the provided ID.
+ *               example: "ncbigene"
+ *               required: true
+ *             id:
+ *               type: string
+ *               description: The provided ID to map to the "dbto" database.
+ *               example: "7157"
+ *               required: true
+ *             dbto:
+ *               type: string
+ *               description: The MIRIAM database prefix of the database to map to.
+ *               example: "uniprot"
+ *               required: true
+ *     responses:
+ *       200:
+ *         description: The metadata for the grounding
+ */
 router.post('/map', function(req, res){
   const { dbfrom, id, dbto } = req.body;
   aggregate.map( dbfrom, id, dbto  ).then( searchRes => res.json( searchRes ) );

--- a/src/server/swagger/index.js
+++ b/src/server/swagger/index.js
@@ -1,16 +1,20 @@
 import express from 'express';
 import swaggerJSDoc from 'swagger-jsdoc';
 import swaggerUi from 'swagger-ui-express';
+import fs from 'fs';
+import { SWAGGER_HOST } from '../config';
 
 const router = express.Router();
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
 export default function( port ) {
   const options = {
     swaggerDefinition: {
       info: {
-        title: 'Swagger docs',
-        version: '0.0.0',
-        description: 'REST API with Swagger doc',
+        title: 'Pathway Commons Grounding Search Service',
+        version: pkg.version,
+        description: 'Get a database grounding for a colloquial biological entity name.  Source code and citation instructions are available on GitHub: [https://github.com/PathwayCommons/grounding-search](`https://github.com/PathwayCommons/grounding-search`)',
         contact: {
           email: 'pathway-commons-help@googlegroups.com'
         }
@@ -21,8 +25,8 @@ export default function( port ) {
           description: 'Grounding Search API'
         }
       ],
-      schemes: ['http'],
-      host: `localhost:${port}`,
+      schemes: SWAGGER_HOST === 'localhost:3000' ? ['http'] : ['https', 'http'],
+      host: SWAGGER_HOST,
       basePath: '/'
     },
     apis: ['./src/server/routes/index.js']


### PR DESCRIPTION
- Add `SWAGGER_HOST` env var.  This needs to be set for Docker configs etc.  By default, it points to `localhost:3000` so that it works out of the box for people who just clone the repo and start the service.  @jvwong, we may need a corresponding update to the Docker compose configs for Biofactoid.
- Docs for `/search`, `/get`, and `/map`.  @jvwong, could you check that your `/map` route isn't missing anything here?
- Examples are included with the Swagger docs, so on the page the user can just click a button to run an example query.  They don't have to write a bunch of JSON just to test things out.
- The Swagger docs page automatically displays the version number specified in `package.json`, so new releases will always display properly without extra prep work.
- For `localhost:3000`, only `http` is allowed.  For others, the user can select `https` or `http` in a dropdown.  We use `https` by default for a public instance.
- More updates to the readme could be made re. #116 after #117 has been merged in.

@jvwong, could you double check that there's nothing missing here, esp. re. `/map`?  If you could try out the query UI in Swagger to see if there's anything I missed, I'd appreciate that.

@metincansiper, you originally set up the Swagger config.  Could you confirm that there's nothing mis-set by these changes?  Thanks

Main page:

<img width="802" alt="Screen Shot 2021-08-11 at 12 15 27" src="https://user-images.githubusercontent.com/989043/129066163-b237d1d8-5dbc-4405-ab9f-1eea680361b3.png">

Docs & example for `/search`:

<img width="802" alt="Screen Shot 2021-08-11 at 12 15 25" src="https://user-images.githubusercontent.com/989043/129066222-b3acec1a-baeb-4899-b276-4524a2e10499.png">

<img width="802" alt="Screen Shot 2021-08-11 at 12 22 13" src="https://user-images.githubusercontent.com/989043/129066338-6fbc4e8a-803a-4210-aaaa-594e1f1ad72a.png">

Result for example query:

<img width="802" alt="Screen Shot 2021-08-11 at 12 15 52" src="https://user-images.githubusercontent.com/989043/129066366-4222a76b-26e8-4655-8568-999b3c8ef1e6.png">

Ref. :

- #116
- #117