### PR TITLE
Drop mapping types

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,17 @@ services:
       - grounding-search-network
     command: ["./wait-for-elasticsearch.sh", "index:9200", "npm", "run", "boot"]
   index:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.7.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0
     restart: unless-stopped
     container_name: index
+    ports:
+      - "9200:9200"
+      - "9300:9300"
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - xpack.security.enabled=false
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
     ulimits:
       memlock:


### PR DESCRIPTION
Remove the mapping types due to deprecation in elasticsearch v7.

Test results:

| branch |   passes  |   failures  | 
|--------|----------|--------- |
| master |  698  |   61  |
| mapping-types |  698  |   61  |

Refs #132 