### PR TITLE
Famplex Part III: `namedComplex`

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -54,7 +54,7 @@ export const DB_PREFIX_FAMPLEX = env('DB_PREFIX_FAMPLEX', 'fplx');
 export const FAMPLEX_URL = env('FAMPLEX_URL', 'https://github.com/sorgerlab/famplex/archive/refs/heads/master.zip');
 export const FAMPLEX_DIRNAME = env('FAMPLEX_DIRNAME', 'famplex-master');
 export const FAMPLEX_FILE_NAME = env('FAMPLEX_FILE_NAME', 'famplex.json');
-export const FAMPLEX_TYPE_FILTER = env('FAMPLEX_TYPE_FILTER', 'protein');
+export const FAMPLEX_TYPE_FILTER = env('FAMPLEX_TYPE_FILTER', 'all');
 
 export const DB_NAME_HGNC_SYMBOL = env('DB_NAME_HGNC_SYMBOL', 'HGNC Symbol');
 export const DB_PREFIX_HGNC_SYMBOL = env('DB_PREFIX_HGNC_SYMBOL', 'hgnc.symbol');

--- a/src/server/datasource/famplex.js
+++ b/src/server/datasource/famplex.js
@@ -33,7 +33,7 @@ const FAMPLEX_XREFS_FILE = 'equivalences.csv';
 const FAMPLEX_SUMMARIES_FILE = 'descriptions.csv';
 const FAMPLEX_RELATIONS_FILE = 'relations.csv';
 const ENTRY_NS = DB_PREFIX_FAMPLEX;
-const ENTRY_TYPE_COMPLEX = 'named-complex';
+const ENTRY_TYPE_COMPLEX = 'namedComplex';
 const ENTRY_TYPE_FAMILY = 'protein';
 const ENTRY_ORGANISM = '9606';
 

--- a/src/server/datasource/famplex.js
+++ b/src/server/datasource/famplex.js
@@ -33,7 +33,7 @@ const FAMPLEX_XREFS_FILE = 'equivalences.csv';
 const FAMPLEX_SUMMARIES_FILE = 'descriptions.csv';
 const FAMPLEX_RELATIONS_FILE = 'relations.csv';
 const ENTRY_NS = DB_PREFIX_FAMPLEX;
-const ENTRY_TYPE_COMPLEX = 'complex';
+const ENTRY_TYPE_COMPLEX = 'named-complex';
 const ENTRY_TYPE_FAMILY = 'protein';
 const ENTRY_ORGANISM = '9606';
 


### PR DESCRIPTION
Complexes are assigned a type `named-complex` to distinguish them from `complex`. Primary reason for this distinction is that existing (factoid) type `complex` are identified at the component-level, and much of the codebase expects the existence of child nodes.

Refs: https://github.com/PathwayCommons/grounding-search/issues/130#issuecomment-1544182783  