### PR TITLE
Remove extraineous filter on search string.

### DIFF
--- a/src/server/datasource/aggregate.js
+++ b/src/server/datasource/aggregate.js
@@ -10,16 +10,6 @@ import Future from 'fibers/future';
 const ROOT_STRAIN_ORGS = Object.values(ROOT_STRAINS).map(getOrganismById);
 const isRootStrainOrgId = id => ROOT_STRAIN_ORGS.some(org => org.is(id));
 
-const filterSearchString = function(searchString){
-  const rnaMatch = searchString.match(/(.*) (.*){0,2}rna/i);
-
-  if( rnaMatch != null ){
-    return rnaMatch[1];
-  } else {
-    return searchString;
-  }
-};
-
 /**
  * Retrieve the entities matching best with the search string.
  * @param {string} searchString Key string for searching the best matching entities.
@@ -34,8 +24,6 @@ const filterSearchString = function(searchString){
  * @returns {Promise} Promise object represents the array of best matching entries.
  */
 const search = function(searchString, namespace = ['ncbi', 'chebi', 'fplx'], organismOrdering){
-  searchString = filterSearchString(searchString);
-
   const doSearch = fuzziness => db.search(searchString, namespace, fuzziness);
   const doRank = ents => rankInThread(ents, searchString, organismOrdering);
   const shortenList = ents => ents.slice(0, MAX_SEARCH_WS);

--- a/test/util/data/molecular-cell.json
+++ b/test/util/data/molecular-cell.json
@@ -1853,7 +1853,7 @@
       "sentence": "( C ) Microscopy of cells infected as in ( A ) and stained with Hoechst 33258 ."
      },
      {
-      "text": "U6 snRNA",
+      "text": "U6",
       "xref_id": "26827",
       "namespace": "ncbi",
       "sentence": "E2f1 and p19Arf were normalized to -Actin ; miRNA signals were normalized to U6 snRNA ."


### PR DESCRIPTION
Remove `filterSearchString` on queries. 
This function accommodated a single failing test case that in fact was not correct (i.e. `U6 snRNA` should be `U6`).