### PR TITLE
Permit empty search results in aggregate tests.

### DIFF
--- a/test/aggregate-quality.js
+++ b/test/aggregate-quality.js
@@ -48,8 +48,12 @@ describe('Search and Get Aggregate', function(){
           return ( searchEnt(text, organismOrdering)
             .then( results => {
               // Actual result is the first result
-              const topResult = _.first( results );
-              const actual = pickRecord( topResult, ground.id );
+              let actual = {};
+              const hasResults = !_.isEmpty( results );
+              if( hasResults ){
+                const topResult = _.first( results );
+                actual = pickRecord( topResult, ground.id );
+              }
 
               // Expected result is the first result that matches the ground truth
               let expected = ground;
@@ -59,7 +63,7 @@ describe('Search and Get Aggregate', function(){
                 const expectedResult = results[rank];
                 expected = pickRecord( expectedResult );
               }
-              const message = JSON.stringify({ text, organismOrdering, expected: expected, actual, rank });
+              const message = JSON.stringify({ text, organismOrdering, expected, actual, rank });
 
               // Compare only namespace and id
               const actualXref = _.pick( actual, [ 'namespace', 'id' ] );

--- a/test/util/quality-reporter.js
+++ b/test/util/quality-reporter.js
@@ -2,6 +2,7 @@ import mocha from 'mocha';
 import _ from 'lodash';
 import { Parser } from 'json2csv';
 import { appendFileSync } from 'fs';
+import logger from '../../src/server/logger';
 
 const isGet = s => /^get/.test( s );
 const isSearch = s => /^search/.test( s );
@@ -20,9 +21,16 @@ const DEFAULT_FIELDS = [
 
 // Yes, hackey, but good enough for this reporter
 const message2JSON = message => {
-  const MESSAGE_RE = /: expected/;
-  const str = _.head( message.split( MESSAGE_RE ) );
-  return JSON.parse(str);
+  try {
+    const MESSAGE_RE = /: expected/;
+    const str = _.head( message.split( MESSAGE_RE ) );
+    return JSON.parse(str);
+
+  } catch( e ) {
+    logger.error( 'Error parsing message' );
+    logger.error( e.message );
+    throw e;
+  }
 };
 
 function write2File( data ) {


### PR DESCRIPTION
Hidden bug: aggregate test module assumes there will always be search results returned. This enables the tests and runners to accept zero search hit results.  