### PR TITLE
More stringent Elasticsearch configuration

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -22,8 +22,8 @@ export const ELASTICSEARCH_HOST = env('ELASTICSEARCH_HOST', 'localhost:9200');
 
 export const MAX_SEARCH_ES = env('MAX_SEARCH_ES', 1000);
 export const MAX_SEARCH_WS = env('MAX_SEARCH_WS', 100);
-export const MAX_FUZZ_ES = env('MAX_FUZZ_ES', 2);
-export const ES_MIN_SCORE = env('ES_MIN_SCORE', 0);
+export const MAX_FUZZ_ES = env('MAX_FUZZ_ES', 1);
+export const ES_MIN_SCORE = env('ES_MIN_SCORE', 0.1);
 
 export const CHUNK_SIZE = env('ENTRIES_CHUNK_SIZE', 100);
 export const MAX_SIMULT_CHUNKS = env('MAX_SIM_CHUNKS', 10);


### PR DESCRIPTION
Config with ES parameters that provide more stringent search, possibility of returning empty results for poor matches.

Refs #161 

---

Reposting from #162 (Green bars represent current settings)

## Test Results

<img width="600px" src="https://github.com/user-attachments/assets/f305e0ca-ce1a-4401-bc50-16f52e538e11" />

**Figure 1.** Search accuracy over different configurations (N=868). A test case fails when the expected ground is not the top search result returned from the grounding-search.

<img width="600px" src="https://github.com/user-attachments/assets/9439ff81-6f65-49aa-a322-24836ba9c869" />

**Figure 2.** Search errors grouped into different classes based on rank. Runner up is second hit; OOD is 'out of dictionary' meaning a ground does not exist but a (non-empty) search hit is returned.