### PR TITLE
Updates to GET endpoint

### DIFF
--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -89,11 +89,16 @@ router.get('/search', function(req, res){
  *     responses:
  *       200:
  *         description: The metadata for the grounding
+ *      404:
+ *        description: The grounding was not found
  */
-router.post('/get', function(req, res){
+router.post('/get', function(req, res, next){
   const { namespace, id } = req.body;
 
-  aggregate.get(namespace, id).then(searchRes => res.json(searchRes));
+  aggregate
+    .get(namespace, id)
+    .then(searchRes => res.json(searchRes))
+    .catch(next);
 });
 
 /**

--- a/test/aggregate-quality.js
+++ b/test/aggregate-quality.js
@@ -87,4 +87,15 @@ describe('Search and Get Aggregate', function(){
 
   }); // SEARCH_OBJECTS
 
+  describe('GET', () => {
+    it('Should not throw when id does exist', function(){
+      const xref_ncbi_known = { namespace: 'ncbi', id: '1' };
+      return expect( getEnt( xref_ncbi_known.namespace, xref_ncbi_known.id ) ).not.to.be.rejected;
+    });
+    it('Should throw when id does not exist', function(){
+      const xref_ncbi_unknown = { namespace: 'ncbi', id: '0' };
+      return expect( getEnt( xref_ncbi_unknown.namespace, xref_ncbi_unknown.id ) ).to.be.rejected;
+    });
+  }); // GET
+
 }); // describe


### PR DESCRIPTION
Updates to the GET endpoint:

- Use the Elasticsearch JS client [get](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/8.7/get_examples.html) API rather than search
- Test: Throws/rejects when GET fails to find document given ID
- Web service: Forwards the HTTP 404 on Error